### PR TITLE
fix: normalize SFS number prefix format across amendment pipeline

### DIFF
--- a/app/actions/change-events.ts
+++ b/app/actions/change-events.ts
@@ -47,6 +47,7 @@ export async function getUnacknowledgedChanges(): Promise<
           amendment_sfs: string | null
           ai_summary: string | null
           detected_at: Date
+          effective_date: Date | null
           list_id: string
           list_name: string
           law_list_item_id: string
@@ -62,6 +63,7 @@ export async function getUnacknowledgedChanges(): Promise<
           ce.amendment_sfs,
           ce.ai_summary,
           ce.detected_at,
+          ad.effective_date,
           ll.id as list_id,
           ll.name as list_name,
           lli.id as law_list_item_id
@@ -69,6 +71,7 @@ export async function getUnacknowledgedChanges(): Promise<
         JOIN legal_documents ld ON ld.id = ce.document_id
         JOIN law_list_items lli ON lli.document_id = ce.document_id
         JOIN law_lists ll ON ll.id = lli.law_list_id
+        LEFT JOIN amendment_documents ad ON ad.sfs_number = ce.amendment_sfs
         LEFT JOIN change_assessments ca
           ON ca.change_event_id = ce.id
           AND ca.law_list_item_id = lli.id
@@ -92,6 +95,7 @@ export async function getUnacknowledgedChanges(): Promise<
         amendmentSfs: ce.amendment_sfs,
         aiSummary: ce.ai_summary,
         detectedAt: ce.detected_at,
+        effectiveDate: ce.effective_date ?? null,
         priority: derivePriority(ce.change_type),
         listId: ce.list_id,
         listName: ce.list_name,
@@ -172,6 +176,7 @@ export async function getUnacknowledgedChangeById(
           amendment_sfs: string | null
           ai_summary: string | null
           detected_at: Date
+          effective_date: Date | null
           list_id: string
           list_name: string
           law_list_item_id: string
@@ -187,6 +192,7 @@ export async function getUnacknowledgedChangeById(
           ce.amendment_sfs,
           ce.ai_summary,
           ce.detected_at,
+          ad.effective_date,
           ll.id as list_id,
           ll.name as list_name,
           lli.id as law_list_item_id
@@ -194,6 +200,7 @@ export async function getUnacknowledgedChangeById(
         JOIN legal_documents ld ON ld.id = ce.document_id
         JOIN law_list_items lli ON lli.document_id = ce.document_id
         JOIN law_lists ll ON ll.id = lli.law_list_id
+        LEFT JOIN amendment_documents ad ON ad.sfs_number = ce.amendment_sfs
         WHERE ce.id = ${changeEventId}
           AND ll.workspace_id = ${ctx.workspaceId}
         LIMIT 1
@@ -214,6 +221,7 @@ export async function getUnacknowledgedChangeById(
         amendmentSfs: ce.amendment_sfs,
         aiSummary: ce.ai_summary,
         detectedAt: ce.detected_at,
+        effectiveDate: ce.effective_date ?? null,
         priority: derivePriority(ce.change_type),
         listId: ce.list_id,
         listName: ce.list_name,

--- a/app/api/cron/discover-sfs-amendments/route.ts
+++ b/app/api/cron/discover-sfs-amendments/route.ts
@@ -48,11 +48,7 @@ import {
   fetchPropositionContext,
 } from '@/lib/riksdagen/proposition-fetcher'
 import { extractEffectiveDate } from '@/lib/external/pdf-parser'
-
-/** Ensure SFS number has "SFS " prefix (idempotent) */
-function ensureSfsPrefix(sfsNumber: string): string {
-  return sfsNumber.startsWith('SFS ') ? sfsNumber : `SFS ${sfsNumber}`
-}
+import { ensureSfsPrefix } from '@/lib/sfs/ensure-prefix'
 
 export const dynamic = 'force-dynamic'
 export const maxDuration = 300 // 5 minutes max for cron
@@ -184,7 +180,9 @@ export async function GET(request: Request) {
           sfs_number: doc.sfsNumber,
           storage_path: constructStoragePath(doc.sfsNumber),
           original_url: doc.pdfUrl,
-          base_law_sfs: doc.baseLawSfs ?? 'unknown',
+          base_law_sfs: doc.baseLawSfs
+            ? ensureSfsPrefix(doc.baseLawSfs)
+            : 'unknown',
           title: doc.title,
           publication_date: new Date(doc.publishedDate),
           parse_status: ParseStatus.PENDING,
@@ -208,7 +206,7 @@ export async function GET(request: Request) {
 
     const unknownRecords = await prisma.amendmentDocument.findMany({
       where: {
-        sfs_number: { startsWith: `${year}:` },
+        sfs_number: { startsWith: `SFS ${year}:` },
         base_law_sfs: 'unknown',
       },
       select: { id: true, sfs_number: true, title: true },
@@ -223,7 +221,7 @@ export async function GET(request: Request) {
         if (resolved) {
           await prisma.amendmentDocument.update({
             where: { id: rec.id },
-            data: { base_law_sfs: resolved },
+            data: { base_law_sfs: ensureSfsPrefix(resolved) },
           })
           console.log(
             `[DISCOVER-SFS] Resolved ${rec.sfs_number}: unknown → ${resolved}`
@@ -240,7 +238,7 @@ export async function GET(request: Request) {
 
     const toProcess = await prisma.amendmentDocument.findMany({
       where: {
-        sfs_number: { startsWith: `${year}:` },
+        sfs_number: { startsWith: `SFS ${year}:` },
         parse_status: { in: [ParseStatus.PENDING, ParseStatus.FAILED] },
         base_law_sfs: { not: 'unknown' },
       },
@@ -293,7 +291,7 @@ export async function GET(request: Request) {
 
     const completedWithoutEvents = await prisma.amendmentDocument.findMany({
       where: {
-        sfs_number: { startsWith: `${year}:` },
+        sfs_number: { startsWith: `SFS ${year}:` },
         parse_status: ParseStatus.COMPLETED,
         base_law_sfs: { not: 'unknown' },
       },
@@ -423,7 +421,7 @@ export async function GET(request: Request) {
 async function computeWatermark(year: number): Promise<number | null> {
   const amendments = await prisma.amendmentDocument.findMany({
     where: {
-      sfs_number: { startsWith: `${year}:` },
+      sfs_number: { startsWith: `SFS ${year}:` },
     },
     select: { sfs_number: true },
   })

--- a/app/api/cron/enrich-amendment-summaries/route.ts
+++ b/app/api/cron/enrich-amendment-summaries/route.ts
@@ -98,7 +98,7 @@ export async function GET(request: Request) {
         MIN(ald.id) as amendment_legal_doc_id
       FROM change_events ce
       JOIN legal_documents bl ON bl.id = ce.document_id
-      JOIN amendment_documents ad ON ad.sfs_number = REPLACE(ce.amendment_sfs, 'SFS ', '')
+      JOIN amendment_documents ad ON ad.sfs_number = ce.amendment_sfs
       LEFT JOIN legal_documents ald ON ald.document_number = ce.amendment_sfs AND ald.content_type = 'SFS_AMENDMENT'
       WHERE ce.ai_summary IS NULL
         AND ce.amendment_sfs IS NOT NULL

--- a/app/api/cron/notify-amendment-changes/route.ts
+++ b/app/api/cron/notify-amendment-changes/route.ts
@@ -280,9 +280,8 @@ export async function GET(request: Request) {
 
       if (ce.amendment_sfs) {
         // Look up AmendmentDocument for effective_date, PDF URL, section changes
-        const sfsNumber = ce.amendment_sfs.replace('SFS ', '')
         const amendmentDoc = await prisma.amendmentDocument.findUnique({
-          where: { sfs_number: sfsNumber },
+          where: { sfs_number: ce.amendment_sfs },
           select: {
             effective_date: true,
             original_url: true,

--- a/app/api/cron/sync-sfs-updates/route.ts
+++ b/app/api/cron/sync-sfs-updates/route.ts
@@ -25,6 +25,7 @@ import { cleanLawHtml } from '@/lib/sfs/clean-law-html'
 import { normalizeSfsLaw } from '@/lib/transforms/normalizers/sfs-law-normalizer'
 import { parseCanonicalHtml } from '@/lib/transforms/canonical-html-parser'
 import { htmlToMarkdown } from '@/lib/transforms/html-to-markdown'
+import { ensureSfsPrefix } from '@/lib/sfs/ensure-prefix'
 
 export const dynamic = 'force-dynamic'
 export const maxDuration = 300 // 5 minutes max for cron
@@ -148,14 +149,14 @@ export async function GET(request: Request) {
         if (!latestAmendment) {
           const latestKnown = await prisma.amendmentDocument.findFirst({
             where: {
-              base_law_sfs: doc.beteckning,
+              base_law_sfs: ensureSfsPrefix(doc.beteckning),
               parse_status: 'COMPLETED',
             },
             orderBy: { sfs_number: 'desc' },
             select: { sfs_number: true },
           })
           if (latestKnown) {
-            latestAmendment = `SFS ${latestKnown.sfs_number}`
+            latestAmendment = latestKnown.sfs_number
             console.log(
               `[SYNC-SFS-UPDATES] ${sfsNumber} undertitel empty, using own data: ${latestAmendment}`
             )

--- a/components/features/ai-chat/details/assessment-detail.tsx
+++ b/components/features/ai-chat/details/assessment-detail.tsx
@@ -64,10 +64,16 @@ function getEffectiveDateBadge(date: Date | null): {
   const diffDays = Math.round(
     (target.getTime() - today.getTime()) / (1000 * 60 * 60 * 24)
   )
+  const dateStr = target.toLocaleDateString('sv-SE', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
   if (diffDays > 0)
-    return { text: `Träder i kraft om ${diffDays} dagar`, variant: 'amber' }
-  if (diffDays === 0) return { text: 'Träder i kraft idag', variant: 'red' }
-  return { text: 'Trädde i kraft', variant: 'green' }
+    return { text: `Träder i kraft ${dateStr}`, variant: 'amber' }
+  if (diffDays === 0)
+    return { text: `Träder i kraft idag (${dateStr})`, variant: 'red' }
+  return { text: `I kraft sedan ${dateStr}`, variant: 'green' }
 }
 
 const EFFECTIVE_DATE_COLORS: Record<string, string> = {

--- a/components/features/dashboard/change-assessment-view.tsx
+++ b/components/features/dashboard/change-assessment-view.tsx
@@ -105,7 +105,7 @@ function ChangeAssessmentViewInner({
       amendmentSfs: change.amendmentSfs ?? '',
       changeType: change.changeType,
       affectedSections: [],
-      effectiveDate: null,
+      effectiveDate: change.effectiveDate ?? null,
       existingAssessment: null,
       documentTitle: change.documentTitle,
       documentNumber: change.documentNumber,

--- a/components/features/dashboard/hem-page.tsx
+++ b/components/features/dashboard/hem-page.tsx
@@ -9,6 +9,7 @@
  */
 
 import { useState, useCallback, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
 import { HemChat } from '@/components/features/dashboard/hem-chat'
 import { ChangeAssessmentView } from '@/components/features/dashboard/change-assessment-view'
 import { LawListGenerationProgress } from '@/components/features/dashboard/law-list-generation-progress'
@@ -33,6 +34,7 @@ export function HemPage({
   initialView,
   generationStatus,
 }: HemPageProps) {
+  const router = useRouter()
   const [activeChange, setActiveChange] = useState<UnacknowledgedChange | null>(
     initialChange ?? null
   )
@@ -58,7 +60,8 @@ export function HemPage({
 
   const handleBack = useCallback(() => {
     setActiveChange(null)
-  }, [])
+    router.refresh()
+  }, [router])
 
   const showGenerationProgress =
     generationStatus === 'pending' ||

--- a/lib/cache/cached-queries.ts
+++ b/lib/cache/cached-queries.ts
@@ -15,6 +15,7 @@ import { unstable_cache } from 'next/cache'
 import { prisma, withRetry } from '@/lib/prisma'
 import { ContentType } from '@prisma/client'
 import { parseSfsFromSlug } from '@/lib/sfs/amendment-slug'
+import { ensureSfsPrefix } from '@/lib/sfs/ensure-prefix'
 import { getCachedDocument } from '@/lib/services/document-cache'
 
 /**
@@ -230,7 +231,7 @@ export const getCachedAmendment = unstable_cache(
     // Get detailed amendment info from AmendmentDocument
     const amendmentDoc = await withRetry(() =>
       prisma.amendmentDocument.findUnique({
-        where: { sfs_number: sfsNumber },
+        where: { sfs_number: ensureSfsPrefix(sfsNumber) },
         include: {
           section_changes: {
             orderBy: { sort_order: 'asc' },
@@ -244,7 +245,9 @@ export const getCachedAmendment = unstable_cache(
     if (amendmentDoc?.base_law_sfs) {
       baseLaw = await withRetry(() =>
         prisma.legalDocument.findUnique({
-          where: { document_number: `SFS ${amendmentDoc.base_law_sfs}` },
+          where: {
+            document_number: ensureSfsPrefix(amendmentDoc.base_law_sfs),
+          },
           select: {
             id: true,
             slug: true,

--- a/lib/changes/change-utils.ts
+++ b/lib/changes/change-utils.ts
@@ -23,6 +23,8 @@ export interface UnacknowledgedChange {
   listName: string
   /** LawListItem ID — the entity that gets acknowledged in Story 8.3 */
   lawListItemId: string
+  /** Effective date from AmendmentDocument (null = unknown) */
+  effectiveDate?: Date | null
   /** Story 14.10: Assessment status (null = unassessed) */
   assessmentStatus?: AssessmentStatus | null
 }

--- a/lib/email/daily-ops-digest.ts
+++ b/lib/email/daily-ops-digest.ts
@@ -152,7 +152,7 @@ export async function gatherIngestionSummary(
     prisma.$queryRaw<[{ count: bigint }]>`
       SELECT COUNT(DISTINCT ce.amendment_sfs)::bigint as count
       FROM change_events ce
-      JOIN amendment_documents ad ON ad.sfs_number = REPLACE(ce.amendment_sfs, 'SFS ', '')
+      JOIN amendment_documents ad ON ad.sfs_number = ce.amendment_sfs
       WHERE ce.ai_summary IS NULL
         AND ce.amendment_sfs IS NOT NULL
         AND ad.parse_status = 'COMPLETED'
@@ -191,7 +191,7 @@ export async function gatherGapDetection(
 
     // Get all amendment_documents SFS numbers for the year
     const amendments = await prisma.amendmentDocument.findMany({
-      where: { sfs_number: { startsWith: `${year}:` } },
+      where: { sfs_number: { startsWith: `SFS ${year}:` } },
       select: { sfs_number: true },
     })
 
@@ -203,16 +203,13 @@ export async function gatherGapDetection(
       select: { document_number: true },
     })
 
+    // Both sides use "SFS YYYY:X" format — direct comparison
     const dbSfsNumbers = new Set<string>()
     for (const a of amendments) {
       dbSfsNumbers.add(a.sfs_number)
     }
     for (const d of legalDocs) {
-      // "SFS 2026:123" -> "2026:123" (robust: handle missing space)
-      const match = d.document_number.match(/(\d{4}:\d+)/)
-      if (match?.[1]) {
-        dbSfsNumbers.add(match[1])
-      }
+      dbSfsNumbers.add(d.document_number)
     }
 
     const missing = [...indexSfsNumbers].filter((sfs) => !dbSfsNumbers.has(sfs))
@@ -305,7 +302,7 @@ export async function gatherAmendmentPipeline(
 ): Promise<AmendmentPipelineStatus> {
   const statuses = await prisma.amendmentDocument.groupBy({
     by: ['parse_status'],
-    where: { sfs_number: { startsWith: `${year}:` } },
+    where: { sfs_number: { startsWith: `SFS ${year}:` } },
     _count: true,
   })
 
@@ -316,7 +313,7 @@ export async function gatherAmendmentPipeline(
 
   const failures = await prisma.amendmentDocument.findMany({
     where: {
-      sfs_number: { startsWith: `${year}:` },
+      sfs_number: { startsWith: `SFS ${year}:` },
       parse_status: ParseStatus.FAILED,
     },
     select: { sfs_number: true, parse_error: true },

--- a/lib/sfs/amendment-to-legal-document.ts
+++ b/lib/sfs/amendment-to-legal-document.ts
@@ -7,6 +7,7 @@
 
 import { PrismaClient, ContentType, DocumentStatus } from '@prisma/client'
 import { generateAmendmentSlug, generateAmendmentTitle } from './amendment-slug'
+import { ensureSfsPrefix } from './ensure-prefix'
 
 type PrismaTransaction = Omit<
   PrismaClient,
@@ -66,7 +67,7 @@ export async function createLegalDocumentFromAmendment(
   )
 
   // Find base law for linking
-  const baseLawDocNumber = `SFS ${amendment.base_law_sfs}`
+  const baseLawDocNumber = ensureSfsPrefix(amendment.base_law_sfs)
   const baseLaw = await tx.legalDocument.findUnique({
     where: { document_number: baseLawDocNumber },
     select: { id: true, slug: true },

--- a/lib/sfs/ensure-prefix.ts
+++ b/lib/sfs/ensure-prefix.ts
@@ -1,0 +1,4 @@
+/** Ensure SFS number has "SFS " prefix (idempotent) */
+export function ensureSfsPrefix(sfsNumber: string): string {
+  return sfsNumber.startsWith('SFS ') ? sfsNumber : `SFS ${sfsNumber}`
+}

--- a/lib/utils/effective-date.ts
+++ b/lib/utils/effective-date.ts
@@ -37,14 +37,20 @@ export function getEffectiveDateBadge(date: Date | null): EffectiveDateBadge {
   const diffMs = target.getTime() - today.getTime()
   const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24))
 
+  const dateStr = target.toLocaleDateString('sv-SE', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+
   if (diffDays > 0) {
-    return { text: `Träder i kraft om ${diffDays} dagar`, variant: 'amber' }
+    return { text: `Träder i kraft ${dateStr}`, variant: 'amber' }
   }
   if (diffDays === 0) {
-    return { text: 'Träder i kraft idag', variant: 'red' }
+    return { text: `Träder i kraft idag (${dateStr})`, variant: 'red' }
   }
   // Past
-  return { text: 'Trädde i kraft', variant: 'green' }
+  return { text: `I kraft sedan ${dateStr}`, variant: 'green' }
 }
 
 // ---------------------------------------------------------------------------

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -790,7 +790,7 @@ model LawSection {
 // Stores the amendment document (PDF) itself - one row per SFS amendment number
 model AmendmentDocument {
   id         String @id @default(cuid())
-  sfs_number String @unique // "2022:1109"
+  sfs_number String @unique // "SFS 2022:1109"
 
   // Storage
   storage_path String // Supabase: "2022/SFS2022-1109.pdf"
@@ -798,7 +798,7 @@ model AmendmentDocument {
   file_size    Int? // Bytes
 
   // Base law reference
-  base_law_sfs  String // "1977:1160" - the law being amended
+  base_law_sfs  String // "SFS 1977:1160" - the law being amended
   base_law_name String? // "arbetsmiljölagen"
 
   // Document metadata

--- a/scripts/backfill-amendment-summaries.ts
+++ b/scripts/backfill-amendment-summaries.ts
@@ -110,7 +110,7 @@ async function main() {
       MIN(ald.id) as amendment_legal_doc_id
     FROM change_events ce
     JOIN legal_documents bl ON bl.id = ce.document_id
-    JOIN amendment_documents ad ON ad.sfs_number = REPLACE(ce.amendment_sfs, 'SFS ', '')
+    JOIN amendment_documents ad ON ad.sfs_number = ce.amendment_sfs
     LEFT JOIN legal_documents ald ON ald.document_number = ce.amendment_sfs AND ald.content_type = 'SFS_AMENDMENT'
     WHERE ce.ai_summary IS NULL
       AND ce.amendment_sfs IS NOT NULL

--- a/scripts/normalize-sfs-prefixes.ts
+++ b/scripts/normalize-sfs-prefixes.ts
@@ -1,0 +1,198 @@
+/**
+ * SFS Prefix Normalization Script
+ *
+ * Normalizes all SFS number fields to use the "SFS YYYY:X" format (WITH prefix).
+ * Removes duplicate amendment_documents created by the format mismatch.
+ *
+ * Run with: npx tsx scripts/normalize-sfs-prefixes.ts
+ * Dry run:  npx tsx scripts/normalize-sfs-prefixes.ts --dry-run
+ */
+
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+const DRY_RUN = process.argv.includes('--dry-run')
+
+async function main() {
+  console.log(`\n${'='.repeat(60)}`)
+  console.log(`SFS Prefix Normalization${DRY_RUN ? ' (DRY RUN)' : ''}`)
+  console.log(`${'='.repeat(60)}\n`)
+
+  // ──────────────────────────────────────────────────────────────────
+  // Step 1: Delete duplicate no-prefix amendment_documents
+  // ──────────────────────────────────────────────────────────────────
+  console.log('## Step 1: Delete duplicate no-prefix amendment_documents')
+
+  const allAmendments = await prisma.amendmentDocument.findMany({
+    where: { sfs_number: { not: { startsWith: 'SFS ' } } },
+    select: { id: true, sfs_number: true, parse_status: true },
+  })
+
+  console.log(`  Found ${allAmendments.length} records without "SFS " prefix`)
+
+  let deletedCount = 0
+  let keptForPrefixing = 0
+
+  for (const record of allAmendments) {
+    const prefixedVersion = `SFS ${record.sfs_number}`
+    const existsWithPrefix = await prisma.amendmentDocument.findUnique({
+      where: { sfs_number: prefixedVersion },
+      select: { id: true },
+    })
+
+    if (existsWithPrefix) {
+      // Duplicate — delete the no-prefix version (prefixed one is authoritative)
+      if (!DRY_RUN) {
+        // section_changes cascade-delete automatically
+        await prisma.amendmentDocument.delete({ where: { id: record.id } })
+      }
+      deletedCount++
+      if (deletedCount <= 5) {
+        console.log(
+          `  Deleted duplicate: ${record.sfs_number} (${record.parse_status})`
+        )
+      }
+    } else {
+      keptForPrefixing++
+    }
+  }
+
+  console.log(`  Deleted: ${deletedCount} duplicates`)
+  console.log(`  Kept for prefixing: ${keptForPrefixing}`)
+
+  // ──────────────────────────────────────────────────────────────────
+  // Step 2: Prefix remaining bare sfs_number records
+  // ──────────────────────────────────────────────────────────────────
+  console.log('\n## Step 2: Prefix remaining bare sfs_number records')
+
+  if (!DRY_RUN) {
+    const result = await prisma.$executeRaw`
+      UPDATE amendment_documents
+      SET sfs_number = 'SFS ' || sfs_number
+      WHERE sfs_number NOT LIKE 'SFS %'
+    `
+    console.log(`  Updated: ${result} records`)
+  } else {
+    const remaining = await prisma.amendmentDocument.count({
+      where: { sfs_number: { not: { startsWith: 'SFS ' } } },
+    })
+    console.log(`  Would update: ${remaining} records`)
+  }
+
+  // ──────────────────────────────────────────────────────────────────
+  // Step 3: Prefix bare base_law_sfs records
+  // ──────────────────────────────────────────────────────────────────
+  console.log('\n## Step 3: Prefix bare base_law_sfs records')
+
+  if (!DRY_RUN) {
+    const result = await prisma.$executeRaw`
+      UPDATE amendment_documents
+      SET base_law_sfs = 'SFS ' || base_law_sfs
+      WHERE base_law_sfs NOT LIKE 'SFS %'
+        AND base_law_sfs != 'unknown'
+    `
+    console.log(`  Updated: ${result} records`)
+  } else {
+    const count = await prisma.amendmentDocument.count({
+      where: {
+        base_law_sfs: { not: { startsWith: 'SFS ' } },
+        NOT: { base_law_sfs: 'unknown' },
+      },
+    })
+    console.log(`  Would update: ${count} records`)
+  }
+
+  // ──────────────────────────────────────────────────────────────────
+  // Step 4: Prefix bare document_versions.amendment_sfs records
+  // ──────────────────────────────────────────────────────────────────
+  console.log('\n## Step 4: Prefix bare document_versions.amendment_sfs')
+
+  if (!DRY_RUN) {
+    const result = await prisma.$executeRaw`
+      UPDATE document_versions
+      SET amendment_sfs = 'SFS ' || amendment_sfs
+      WHERE amendment_sfs IS NOT NULL
+        AND amendment_sfs NOT LIKE 'SFS %'
+    `
+    console.log(`  Updated: ${result} records`)
+  } else {
+    const count = await prisma.documentVersion.count({
+      where: {
+        amendment_sfs: { not: null },
+        NOT: { amendment_sfs: { startsWith: 'SFS ' } },
+      },
+    })
+    console.log(`  Would update: ${count} records`)
+  }
+
+  // ──────────────────────────────────────────────────────────────────
+  // Verification
+  // ──────────────────────────────────────────────────────────────────
+  if (!DRY_RUN) {
+    console.log('\n## Verification')
+
+    const bareSfsNumber = await prisma.amendmentDocument.count({
+      where: { sfs_number: { not: { startsWith: 'SFS ' } } },
+    })
+    console.log(
+      `  Bare sfs_number remaining: ${bareSfsNumber}${bareSfsNumber === 0 ? ' ✓' : ' ✗ UNEXPECTED'}`
+    )
+
+    const bareBaseLaw = await prisma.amendmentDocument.count({
+      where: {
+        base_law_sfs: { not: { startsWith: 'SFS ' } },
+        NOT: { base_law_sfs: 'unknown' },
+      },
+    })
+    console.log(
+      `  Bare base_law_sfs remaining: ${bareBaseLaw}${bareBaseLaw === 0 ? ' ✓' : ' ✗ UNEXPECTED'}`
+    )
+
+    const bareVersions = await prisma.documentVersion.count({
+      where: {
+        amendment_sfs: { not: null },
+        NOT: { amendment_sfs: { startsWith: 'SFS ' } },
+      },
+    })
+    console.log(
+      `  Bare document_versions.amendment_sfs remaining: ${bareVersions}${bareVersions === 0 ? ' ✓' : ' ✗ UNEXPECTED'}`
+    )
+
+    // Check for duplicates
+    const dupes = await prisma.$queryRawUnsafe<
+      { sfs_number: string; cnt: bigint }[]
+    >(`
+      SELECT sfs_number, COUNT(*) as cnt
+      FROM amendment_documents
+      GROUP BY sfs_number
+      HAVING COUNT(*) > 1
+    `)
+    console.log(
+      `  Duplicate sfs_numbers: ${dupes.length}${dupes.length === 0 ? ' ✓' : ' ✗ UNEXPECTED'}`
+    )
+    if (dupes.length > 0) {
+      for (const d of dupes.slice(0, 5)) {
+        console.log(`    ${d.sfs_number}: ${d.cnt}`)
+      }
+    }
+
+    const totalAmendments = await prisma.amendmentDocument.count()
+    console.log(`  Total amendment_documents: ${totalAmendments}`)
+  }
+
+  console.log(`\n${'='.repeat(60)}`)
+  console.log(
+    DRY_RUN
+      ? 'Dry run complete. Run without --dry-run to apply.'
+      : 'Normalization complete.'
+  )
+  console.log(`${'='.repeat(60)}\n`)
+
+  await prisma.$disconnect()
+}
+
+main().catch(async (e) => {
+  console.error('Script failed:', e)
+  await prisma.$disconnect()
+  process.exit(1)
+})

--- a/tests/unit/lib/utils/effective-date.test.ts
+++ b/tests/unit/lib/utils/effective-date.test.ts
@@ -20,35 +20,35 @@ describe('getEffectiveDateBadge', () => {
     expect(badge.text).toContain('okänt')
   })
 
-  it('returns amber variant for future date', () => {
+  it('returns amber variant for future date with formatted date', () => {
     const future = new Date()
     future.setDate(future.getDate() + 30)
     const badge = getEffectiveDateBadge(future)
     expect(badge.variant).toBe('amber')
-    expect(badge.text).toContain('Träder i kraft om')
-    expect(badge.text).toContain('dagar')
+    expect(badge.text).toContain('Träder i kraft')
+    expect(badge.text).not.toContain('okänt')
   })
 
-  it('returns red variant for today', () => {
+  it('returns red variant for today with date', () => {
     const badge = getEffectiveDateBadge(new Date())
     expect(badge.variant).toBe('red')
-    expect(badge.text).toBe('Träder i kraft idag')
+    expect(badge.text).toContain('Träder i kraft idag')
   })
 
-  it('returns green variant for past date', () => {
+  it('returns green variant for past date with formatted date', () => {
     const past = new Date()
     past.setDate(past.getDate() - 10)
     const badge = getEffectiveDateBadge(past)
     expect(badge.variant).toBe('green')
-    expect(badge.text).toBe('Trädde i kraft')
+    expect(badge.text).toContain('I kraft sedan')
   })
 
-  it('returns 1 day for tomorrow', () => {
+  it('returns amber for tomorrow with formatted date', () => {
     const tomorrow = new Date()
     tomorrow.setDate(tomorrow.getDate() + 1)
     const badge = getEffectiveDateBadge(tomorrow)
     expect(badge.variant).toBe('amber')
-    expect(badge.text).toContain('1 dagar')
+    expect(badge.text).toContain('Träder i kraft')
   })
 })
 


### PR DESCRIPTION
## Summary
- **Fixed SFS prefix inconsistency** in `amendment_documents` — 99.2% of records used `"SFS YYYY:X"` format but 289 had bare `"YYYY:X"`, causing 275 duplicate records, broken SQL JOINs, silent lookup failures, and inflated pipeline counts
- **Wired up effective date** in change assessment UI — was hardcoded to `null`, now fetched from `amendment_documents` and displayed with actual date
- **Fixed stale dashboard count** — added `router.refresh()` when returning from assessment view

## Changes
- Extract shared `ensureSfsPrefix` utility (`lib/sfs/ensure-prefix.ts`)
- Add `normalize-sfs-prefixes.ts` DB cleanup script (already run against prod — 275 duplicates deleted, all fields normalized)
- Fix 6 broken `startsWith` queries, 3 broken SQL JOINs, 2 broken `findUnique` lookups, 4 double-prefix bugs
- Add `LEFT JOIN amendment_documents` to change event queries for effective date
- Improve effective date badge to show formatted date instead of raw day count

## Test plan
- [x] 3205 unit tests passing
- [x] Daily ops digest verified locally — gap detection shows 1 missing (correct), pipeline shows PENDING 1 / COMPLETED 274
- [x] Amendment ingestion pipeline verified — discovery, watermark, dedup, and PENDING creation all work with prefixed format
- [x] Effective date badge renders actual date in assessment sidebar
- [x] DB normalization script run and verified (0 bare records, 0 duplicates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)