### PR TITLE
feat(security): enable RLS on all public tables to gate PostgREST access

### DIFF
--- a/prisma/migrations/20260430120000_enable_rls_public_tables/migration.sql
+++ b/prisma/migrations/20260430120000_enable_rls_public_tables/migration.sql
@@ -1,0 +1,70 @@
+-- Enable RLS on every public table to deny PostgREST/Realtime/pg_graphql
+-- access via the leaked anon key. Prisma connects as the `postgres` role
+-- (BYPASSRLS), so server-side queries are unaffected. No policies are
+-- defined: RLS-enabled-no-policy = default deny for non-bypass roles.
+
+ALTER TABLE "public"."activity_logs" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."admin_audit_logs" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."amendment_documents" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."amendments" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."change_assessments" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."change_events" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."chat_messages" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."chat_usage_events" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."comments" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."company_profiles" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."compliance_audit_cycles" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."compliance_audit_items" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."compliance_audit_reports" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."compliance_cycle_task_links" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."compliance_findings" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."compliance_status_logs" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."content_chunks" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."court_cases" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."cron_job_runs" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."cross_references" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."document_subjects" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."document_versions" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."document_visits" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."eu_documents" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."file_list_item_links" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."file_task_links" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."law_list_groups" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."law_list_item_requirements" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."law_list_items" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."law_list_templates" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."law_lists" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."law_sections" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."legal_documents" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."legislative_refs" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."notification_preferences" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."notifications" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."requirement_evidence_links" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."section_changes" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."task_columns" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."task_list_item_links" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."tasks" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."template_items" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."template_sections" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."users" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."workspace_document_list_item_links" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."workspace_document_task_links" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."workspace_document_templates" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."workspace_document_versions" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."workspace_documents" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."workspace_files" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."workspace_invitations" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."workspace_members" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."workspaces" ENABLE ROW LEVEL SECURITY;
+
+-- Prisma's internal migration-tracking table. No PII, but enabling RLS
+-- clears the Supabase linter warning. Prisma's role bypasses, so migrate
+-- continues to read/write it normally.
+ALTER TABLE "public"."_prisma_migrations" ENABLE ROW LEVEL SECURITY;
+
+-- Verification: this query must return zero rows after migration applies.
+-- (Commented because Prisma migrate cannot evaluate assertions; run manually.)
+--
+-- SELECT schemaname, tablename
+-- FROM pg_tables
+-- WHERE schemaname = 'public' AND NOT rowsecurity;

--- a/scripts/rls-rollback/rollback_20260430120000_enable_rls_public_tables.sql
+++ b/scripts/rls-rollback/rollback_20260430120000_enable_rls_public_tables.sql
@@ -1,0 +1,63 @@
+-- Rollback for migration 20260430120000_enable_rls_public_tables
+-- Disables RLS on every public table this migration enabled it on.
+-- Apply manually via psql against DIRECT_URL if you need to revert.
+--
+-- After running this you will ALSO need to remove the migration row from
+-- _prisma_migrations or Prisma will think the migration is still applied:
+--   DELETE FROM _prisma_migrations
+--   WHERE migration_name = '20260430120000_enable_rls_public_tables';
+
+ALTER TABLE "public"."activity_logs" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."admin_audit_logs" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."amendment_documents" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."amendments" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."change_assessments" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."change_events" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."chat_messages" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."chat_usage_events" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."comments" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."company_profiles" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."compliance_audit_cycles" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."compliance_audit_items" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."compliance_audit_reports" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."compliance_cycle_task_links" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."compliance_findings" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."compliance_status_logs" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."content_chunks" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."court_cases" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."cron_job_runs" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."cross_references" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."document_subjects" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."document_versions" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."document_visits" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."eu_documents" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."file_list_item_links" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."file_task_links" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."law_list_groups" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."law_list_item_requirements" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."law_list_items" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."law_list_templates" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."law_lists" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."law_sections" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."legal_documents" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."legislative_refs" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."notification_preferences" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."notifications" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."requirement_evidence_links" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."section_changes" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."task_columns" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."task_list_item_links" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."tasks" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."template_items" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."template_sections" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."users" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."workspace_document_list_item_links" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."workspace_document_task_links" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."workspace_document_templates" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."workspace_document_versions" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."workspace_documents" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."workspace_files" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."workspace_invitations" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."workspace_members" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."workspaces" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."_prisma_migrations" DISABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary

- Enables row-level security on every `public.*` table (53 Prisma-mapped tables + `_prisma_migrations`) without policies. Default-denies the `anon` and `authenticated` PostgREST roles, leaving Prisma (`postgres` role, `BYPASSRLS`) unaffected.
- Closes the leaked-anon-key exposure where any client could read every row over `<project>.supabase.co/rest/v1/*` or `/graphql/v1` using the public `NEXT_PUBLIC_SUPABASE_ANON_KEY`.
- Includes a manual rollback script under `scripts/rls-rollback/` for emergencies.

## Why this is safe for our stack

- Prisma connects as `postgres.<project>` via the Supabase pooler — `BYPASSRLS` is set on this role, so server-side queries are untouched.
- The Supabase JS client in this codebase only ever calls `supabase.auth.*` (verified across `app/`, `components/`, `lib/`, `scripts/`). Zero `.from(...)`, `.rpc(...)`, or `.channel(...)` calls — nothing in the app talks to PostgREST.
- Storage (`sfs-pdfs` bucket) uses the service-role client (also `BYPASSRLS`) — unaffected.
- Vercel crons → HTTP route handlers → Prisma → unaffected.
- Triggers and `$queryRaw`/`$executeRaw` run in the Prisma connection — unaffected.

## Deploy state

Already applied to **production** via Supabase Studio SQL editor on 2026-04-30. Reconciled with `prisma migrate resolve --applied 20260430120000_enable_rls_public_tables`. This commit captures the migration in version control so `prisma migrate deploy` is a no-op going forward.

App was smoke-tested post-apply: login, `/laglistor`, document load, OAuth, settings — all functional.

## Verification

```sql
SELECT schemaname, tablename FROM pg_tables
WHERE schemaname = 'public' AND NOT rowsecurity;
-- expect: zero rows
```

Confirmed zero rows in production.

## Test plan

- [x] Run migration SQL in Supabase Studio (production)
- [x] Verification query returns zero rows
- [x] Smoke test: login, list, document, settings, OAuth callback
- [x] `prisma migrate resolve --applied` (production bookkeeping reconciled)
- [x] Pre-push CI: `tsc --noEmit` + `next build` pass
- [x] Reviewer confirms migration covers exactly the tables in `prisma/schema.prisma`

## Latent items (not blockers)

- If anyone later adds Realtime subscriptions or browser-side `supabase.from(...)` queries, results will silently return `[]` until a policy is written. Worth a note in `docs/database-setup.md`.
- `prisma db push` (schema-diff, not migrate) won't restore RLS on a fresh DB. Use `migrate deploy` for prod-shaped envs.
- OAuth users carry an unused but valid Supabase access-token cookie for ~1h after each Google sign-in (pre-existing, not made worse here). Worth a follow-up ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)