### PR TITLE
Doc fixes + legal-modal left-panel redesign

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"0643063b-812d-4faf-a4ca-af8b7132b1df","pid":3488,"acquiredAt":1776153788136}
+{"sessionId":"df6941ba-47c9-48cd-b42d-ce8ee5187730","pid":28526,"procStart":"Mon May 18 16:36:24 2026","acquiredAt":1779198033666}

--- a/_prototypes/empty-state-consistency.html
+++ b/_prototypes/empty-state-consistency.html
@@ -1,0 +1,1172 @@
+<!doctype html>
+<html lang="sv">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Laglig — Empty-state consistency audit + unified pattern</title>
+
+  <style>
+    @font-face {
+      font-family: 'Safiro';
+      src:
+        url('../public/fonts/safiro-medium-webfont.woff2') format('woff2'),
+        url('../public/fonts/safiro-medium-webfont.woff') format('woff');
+      font-weight: 500;
+      font-style: normal;
+      font-display: swap;
+    }
+    @font-face {
+      font-family: 'Google Sans Flex';
+      src: url('../public/fonts/GoogleSansFlex.ttf') format('truetype');
+      font-weight: 100 900;
+      font-style: normal;
+      font-display: swap;
+    }
+
+    /* Dark theme tokens — mirrored from app/globals.css :root.dark */
+    :root {
+      --background: 0 0% 10%;
+      --foreground: 0 0% 93%;
+      --card: 0 0% 9%;
+      --card-foreground: 0 0% 93%;
+      --popover: 0 0% 14%;
+      --primary: 0 0% 93%;
+      --primary-foreground: 0 0% 10%;
+      --secondary: 0 0% 17%;
+      --muted: 0 0% 17%;
+      --muted-foreground: 0 0% 64%;
+      --accent: 0 0% 17%;
+      --border: 0 0% 19%;
+      --input: 0 0% 19%;
+      --ring: 0 0% 64%;
+      --radius: 0.5rem;
+    }
+
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: 'Google Sans Flex', system-ui, -apple-system, sans-serif;
+      font-size: 14px;
+      line-height: 1.5;
+      color: hsl(var(--foreground));
+      background: hsl(var(--background));
+      -webkit-font-smoothing: antialiased;
+    }
+    .font-safiro { font-family: 'Safiro', system-ui, sans-serif; font-weight: 500; }
+
+    /* Page chrome */
+    .page {
+      max-width: 1400px;
+      margin: 0 auto;
+      padding: 40px 32px 80px;
+    }
+    .doc-header {
+      border-bottom: 1px solid hsl(var(--border));
+      padding-bottom: 24px;
+      margin-bottom: 32px;
+    }
+    .doc-header h1 {
+      font-family: 'Safiro', system-ui, sans-serif;
+      font-weight: 500;
+      font-size: 32px;
+      letter-spacing: -0.01em;
+      margin: 0 0 8px;
+    }
+    .doc-header p {
+      margin: 0;
+      color: hsl(var(--muted-foreground));
+      font-size: 15px;
+      max-width: 720px;
+    }
+    .section {
+      margin-top: 56px;
+    }
+    .section > h2 {
+      font-family: 'Safiro', system-ui, sans-serif;
+      font-weight: 500;
+      font-size: 20px;
+      margin: 0 0 6px;
+    }
+    .section > .lede {
+      color: hsl(var(--muted-foreground));
+      font-size: 13.5px;
+      margin: 0 0 24px;
+      max-width: 760px;
+    }
+    .kicker {
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-size: 11px;
+      color: hsl(var(--muted-foreground));
+      font-weight: 600;
+      margin: 0 0 8px;
+    }
+
+    /* Faux page surface mocking an in-app list page */
+    .surface {
+      background: hsl(var(--card));
+      border: 1px solid hsl(var(--border));
+      border-radius: 12px;
+      overflow: hidden;
+    }
+    .surface__crumb {
+      padding: 14px 20px;
+      border-bottom: 1px solid hsl(var(--border));
+      font-size: 12px;
+      color: hsl(var(--muted-foreground));
+    }
+    .surface__crumb strong {
+      color: hsl(var(--foreground));
+      font-weight: 500;
+    }
+    .surface__head {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      padding: 18px 20px 14px;
+      gap: 16px;
+    }
+    .surface__head h3 {
+      margin: 0 0 4px;
+      font-family: 'Safiro', system-ui, sans-serif;
+      font-weight: 500;
+      font-size: 22px;
+      letter-spacing: -0.005em;
+    }
+    .surface__head .sub {
+      margin: 0;
+      font-size: 12.5px;
+      color: hsl(var(--muted-foreground));
+    }
+    .surface__head .actions {
+      display: flex;
+      gap: 8px;
+      flex-shrink: 0;
+    }
+    .surface__toolbar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 10px 20px;
+      border-top: 1px solid hsl(var(--border));
+      border-bottom: 1px solid hsl(var(--border));
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+    .surface__toolbar-left,
+    .surface__toolbar-right {
+      display: flex;
+      gap: 8px;
+      align-items: center;
+    }
+    .surface__body {
+      padding: 56px 20px 64px;
+      min-height: 280px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    /* Generic chip / button / input chrome */
+    .chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      height: 28px;
+      padding: 0 10px;
+      border-radius: 6px;
+      font-size: 12.5px;
+      color: hsl(var(--foreground));
+      background: hsl(var(--secondary));
+      border: 1px solid transparent;
+    }
+    .chip.muted { background: transparent; color: hsl(var(--muted-foreground)); }
+    .chip.active { background: hsl(var(--accent)); }
+    .chip .count {
+      background: hsl(var(--muted));
+      color: hsl(var(--muted-foreground));
+      font-size: 11px;
+      padding: 1px 6px;
+      border-radius: 999px;
+      margin-left: 2px;
+    }
+    .input {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      height: 28px;
+      padding: 0 10px;
+      border-radius: 6px;
+      background: hsl(var(--secondary));
+      color: hsl(var(--muted-foreground));
+      font-size: 12.5px;
+      min-width: 180px;
+    }
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      height: 32px;
+      padding: 0 14px;
+      border-radius: 6px;
+      font-size: 13px;
+      font-weight: 500;
+      border: 1px solid hsl(var(--border));
+      background: transparent;
+      color: hsl(var(--foreground));
+      cursor: pointer;
+      transition: background 120ms ease;
+    }
+    .btn:hover { background: hsl(var(--accent)); }
+    .btn--primary {
+      background: hsl(var(--primary));
+      color: hsl(var(--primary-foreground));
+      border-color: hsl(var(--primary));
+    }
+    .btn--primary:hover { opacity: 0.92; background: hsl(var(--primary)); }
+    .btn--ghost { border-color: transparent; }
+    .btn--sm { height: 28px; padding: 0 10px; font-size: 12px; }
+
+    /* ---------- Current empty-state mimics (kept faithful to screenshots) ---------- */
+
+    /* Styrdokument */
+    .current-styr .icon-wrap {
+      width: 56px; height: 56px; border-radius: 999px;
+      background: hsl(var(--muted));
+      display: grid; place-items: center;
+      color: hsl(var(--muted-foreground));
+      margin-bottom: 18px;
+    }
+    .current-styr h4 {
+      margin: 0 0 4px;
+      font-size: 15px;
+      font-weight: 500;
+    }
+    .current-styr p {
+      margin: 0 0 18px;
+      font-size: 12.5px;
+      color: hsl(var(--muted-foreground));
+    }
+    .current-styr .ctas { display: flex; gap: 8px; justify-content: center; }
+    .center { display: flex; flex-direction: column; align-items: center; text-align: center; }
+
+    /* Uppgifter — smaller icon, no CTA */
+    .current-task .icon-wrap {
+      width: 44px; height: 44px; border-radius: 999px;
+      background: hsl(var(--muted));
+      display: grid; place-items: center;
+      color: hsl(var(--muted-foreground));
+      margin-bottom: 14px;
+    }
+    .current-task h4 { margin: 0 0 4px; font-size: 14px; font-weight: 500; }
+    .current-task p { margin: 0; font-size: 12px; color: hsl(var(--muted-foreground)); }
+
+    /* Laglistor — no title, smaller icon, inline copy */
+    .current-laglistor .icon-wrap {
+      width: 44px; height: 44px; border-radius: 999px;
+      background: hsl(var(--muted));
+      display: grid; place-items: center;
+      color: hsl(var(--muted-foreground));
+      margin-bottom: 14px;
+    }
+    .current-laglistor p {
+      margin: 0;
+      font-size: 12.5px;
+      color: hsl(var(--muted-foreground));
+      max-width: 280px;
+    }
+
+    /* Kontroller — no icon, has CTA */
+    .current-kontroller p {
+      margin: 0 0 14px;
+      font-size: 12.5px;
+      color: hsl(var(--muted-foreground));
+    }
+
+    /* Filer — folder icon + primary CTA */
+    .current-filer .icon-wrap {
+      width: 56px; height: 56px;
+      display: grid; place-items: center;
+      color: hsl(var(--muted-foreground));
+      margin-bottom: 14px;
+    }
+    .current-filer h4 { margin: 0 0 4px; font-size: 14px; font-weight: 500; }
+    .current-filer p { margin: 0 0 16px; font-size: 12.5px; color: hsl(var(--muted-foreground)); }
+
+    /* ---------- Variance call-outs ---------- */
+    .audit-row {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr);
+      gap: 24px;
+      margin-bottom: 28px;
+    }
+    .audit-card {
+      display: grid;
+      grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+      gap: 20px;
+      align-items: stretch;
+    }
+    @media (max-width: 900px) {
+      .audit-card { grid-template-columns: 1fr; }
+    }
+    .audit-meta {
+      padding: 18px 20px;
+      background: hsl(var(--secondary));
+      border: 1px solid hsl(var(--border));
+      border-radius: 12px;
+    }
+    .audit-meta h5 {
+      margin: 0 0 8px;
+      font-family: 'Safiro', system-ui, sans-serif;
+      font-weight: 500;
+      font-size: 15px;
+    }
+    .audit-meta ul {
+      margin: 0;
+      padding-left: 18px;
+      color: hsl(var(--muted-foreground));
+      font-size: 13px;
+    }
+    .audit-meta ul li { margin-bottom: 4px; }
+    .audit-meta .tag {
+      display: inline-block;
+      font-size: 11px;
+      padding: 2px 8px;
+      border-radius: 999px;
+      background: hsl(var(--background));
+      color: hsl(var(--muted-foreground));
+      margin-right: 6px;
+      margin-bottom: 8px;
+      border: 1px solid hsl(var(--border));
+    }
+    .audit-meta .tag.bad { color: #f87171; border-color: rgba(248,113,113,0.35); }
+    .audit-meta .tag.ok { color: #86efac; border-color: rgba(134,239,172,0.35); }
+
+    /* ---------- Unified empty-state primitive ---------- */
+    .empty {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      text-align: center;
+      gap: 18px;
+      max-width: 460px;
+      margin: 0 auto;
+    }
+    .empty__icon {
+      width: 56px;
+      height: 56px;
+      border-radius: 999px;
+      background: hsl(var(--muted));
+      display: grid;
+      place-items: center;
+      color: hsl(var(--muted-foreground));
+    }
+    .empty__text { display: flex; flex-direction: column; gap: 4px; }
+    .empty__title {
+      font-family: 'Safiro', system-ui, sans-serif;
+      font-weight: 500;
+      font-size: 17px;
+      margin: 0;
+      letter-spacing: -0.003em;
+      color: hsl(var(--foreground));
+    }
+    .empty__sub {
+      margin: 0;
+      font-size: 13px;
+      color: hsl(var(--muted-foreground));
+      line-height: 1.55;
+    }
+    .empty__actions {
+      display: flex;
+      gap: 10px;
+      justify-content: center;
+    }
+    /* Filtered variant — softer, no big primary */
+    .empty.filtered .empty__icon {
+      width: 44px;
+      height: 44px;
+      background: transparent;
+      border: 1px dashed hsl(var(--border));
+    }
+
+    /* ---------- Anatomy callouts ---------- */
+    .anatomy {
+      display: grid;
+      grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+      gap: 24px;
+      background: hsl(var(--card));
+      border: 1px solid hsl(var(--border));
+      border-radius: 12px;
+      padding: 28px 28px 32px;
+    }
+    @media (max-width: 900px) {
+      .anatomy { grid-template-columns: 1fr; }
+    }
+    .anatomy__demo {
+      display: grid;
+      gap: 28px;
+    }
+    .anatomy__notes h4 {
+      margin: 0 0 10px;
+      font-size: 13px;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: hsl(var(--muted-foreground));
+    }
+    .anatomy__notes ul {
+      margin: 0 0 18px;
+      padding-left: 18px;
+      font-size: 13.5px;
+    }
+    .anatomy__notes ul li { margin-bottom: 6px; }
+    .anatomy__notes code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 12px;
+      background: hsl(var(--muted));
+      padding: 1px 6px;
+      border-radius: 4px;
+    }
+
+    /* ---------- Unified grid for the five pages, after ---------- */
+    .unified-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 20px;
+    }
+    @media (max-width: 1100px) { .unified-grid { grid-template-columns: 1fr; } }
+    .unified-grid .surface { min-height: 360px; }
+
+    /* Filtered-empty section grid */
+    .filtered-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 20px;
+    }
+    @media (max-width: 1100px) { .filtered-grid { grid-template-columns: 1fr; } }
+
+    /* svg icon size */
+    .icon-md svg { width: 22px; height: 22px; }
+    .icon-lg svg { width: 26px; height: 26px; }
+    .icon-sm svg { width: 14px; height: 14px; }
+
+    /* Section label */
+    .section-label {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: hsl(var(--muted-foreground));
+      margin-bottom: 6px;
+      font-weight: 600;
+    }
+    .badge-current {
+      background: rgba(248,113,113,0.12);
+      color: #f87171;
+      padding: 2px 8px;
+      border-radius: 999px;
+      font-size: 10.5px;
+      letter-spacing: 0.04em;
+    }
+    .badge-after {
+      background: rgba(134,239,172,0.12);
+      color: #86efac;
+      padding: 2px 8px;
+      border-radius: 999px;
+      font-size: 10.5px;
+      letter-spacing: 0.04em;
+    }
+
+    /* Principles list */
+    .principles {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 16px;
+    }
+    @media (max-width: 900px) { .principles { grid-template-columns: 1fr; } }
+    .principle {
+      padding: 18px 20px;
+      background: hsl(var(--card));
+      border: 1px solid hsl(var(--border));
+      border-radius: 10px;
+    }
+    .principle .pnum {
+      font-family: 'Safiro', system-ui, sans-serif;
+      font-weight: 500;
+      color: hsl(var(--muted-foreground));
+      font-size: 12px;
+      letter-spacing: 0.08em;
+    }
+    .principle h5 {
+      margin: 6px 0 8px;
+      font-family: 'Safiro', system-ui, sans-serif;
+      font-weight: 500;
+      font-size: 15px;
+    }
+    .principle p {
+      margin: 0;
+      font-size: 13px;
+      color: hsl(var(--muted-foreground));
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <header class="doc-header">
+      <p class="kicker">Prototype · Empty states · 2026-05-21</p>
+      <h1>One empty state, five list pages</h1>
+      <p>
+        Today every list page in Laglig draws its own empty state. The visual weight,
+        icon, title voice, and CTA placement all differ. This prototype audits the
+        variance, names a single primitive (the existing <code>&lt;EmptyState&gt;</code>),
+        and shows the five pages re-rendered through it — with a clean split between
+        <strong>truly empty</strong> (first-run) and <strong>filtered empty</strong> (no matches).
+      </p>
+    </header>
+
+    <!-- ============================================================ -->
+    <!-- SECTION 1 — Current state audit                              -->
+    <!-- ============================================================ -->
+    <section class="section">
+      <h2>1 — Today, five different empty states</h2>
+      <p class="lede">
+        Side-by-side snapshots of the five list pages. Each cell highlights what
+        differs from its neighbours.
+      </p>
+
+      <!-- Styrdokument -->
+      <div class="audit-row">
+        <div class="audit-card">
+          <div class="surface">
+            <div class="surface__crumb">Bygg &amp; Fastighet AB &nbsp;›&nbsp; <strong>Styrdokument</strong></div>
+            <div class="surface__head">
+              <div>
+                <h3>Styrdokument</h3>
+                <p class="sub">Policyer, rutiner och instruktioner med versionshistorik</p>
+              </div>
+              <div class="actions">
+                <button class="btn"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M17 8l-5-5-5 5M12 3v12"/></svg>Importera</button>
+                <button class="btn btn--primary"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>Nytt dokument</button>
+              </div>
+            </div>
+            <div class="surface__toolbar">
+              <div class="surface__toolbar-left">
+                <span class="chip active"><svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg>Aktiva</span>
+                <span class="chip muted"><svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/></svg>Arkiverade</span>
+              </div>
+              <div class="surface__toolbar-right">
+                <span class="input"><svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>Sök dokument…</span>
+                <span class="chip">Dokumenttyp</span>
+                <span class="chip">Status</span>
+              </div>
+            </div>
+            <div class="surface__body current-styr">
+              <div class="center">
+                <div class="icon-wrap icon-lg">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+                </div>
+                <h4>Inga styrdokument ännu</h4>
+                <p>Kom igång genom att skapa ett nytt styrdokument eller importera ett befintligt.</p>
+                <div class="ctas">
+                  <button class="btn btn--primary btn--sm"><svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>Nytt dokument</button>
+                  <button class="btn btn--sm"><svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M17 8l-5-5-5 5M12 3v12"/></svg>Importera</button>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="audit-meta">
+            <span class="badge-current">Current</span>
+            <h5 style="margin-top:8px">Styrdokument</h5>
+            <ul>
+              <li>Icon: 56px, rounded muted-bg</li>
+              <li>Title: "Inga X <em>ännu</em>"</li>
+              <li>Body CTAs: primary <strong>+</strong> secondary</li>
+              <li>Same CTAs duplicated in toolbar</li>
+            </ul>
+            <span class="tag ok">Title voice ✓</span>
+            <span class="tag ok">Dual CTA ✓</span>
+            <span class="tag bad">No filtered-empty variant</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Uppgifter -->
+      <div class="audit-row">
+        <div class="audit-card">
+          <div class="surface">
+            <div class="surface__crumb">Bygg &amp; Fastighet AB &nbsp;›&nbsp; <strong>Uppgifter</strong></div>
+            <div class="surface__head">
+              <div>
+                <h3>Uppgifter</h3>
+                <p class="sub">Hantera och spåra efterlevnadsuppgifter för din organisation.</p>
+              </div>
+              <div class="actions">
+                <button class="btn btn--primary">+ Ny uppgift</button>
+              </div>
+            </div>
+            <div class="surface__toolbar">
+              <div class="surface__toolbar-left">
+                <span class="chip muted">Sammanfattning</span>
+                <span class="chip muted">Aktiva</span>
+                <span class="chip active">Lista</span>
+                <span class="chip muted">Kalender</span>
+                <span class="chip muted">Alla uppgifter</span>
+              </div>
+            </div>
+            <div class="surface__toolbar" style="border-top:none">
+              <div class="surface__toolbar-left">
+                <span class="input">🔍 Sök uppgifter…</span>
+                <span class="chip">Status ▾</span>
+                <span class="chip">Prioritet ▾</span>
+                <span class="chip">Förfallodatum ▾</span>
+                <span class="chip">Alla ▾</span>
+              </div>
+              <div class="surface__toolbar-right">
+                <span class="chip muted">⇄ Kolumner</span>
+              </div>
+            </div>
+            <div class="surface__body current-task">
+              <div class="center">
+                <div class="icon-wrap">
+                  <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M8 10h8M8 14h6"/></svg>
+                </div>
+                <h4>Inga uppgifter matchar</h4>
+                <p>Justera dina filter eller skapa en ny uppgift</p>
+              </div>
+            </div>
+          </div>
+          <div class="audit-meta">
+            <span class="badge-current">Current</span>
+            <h5 style="margin-top:8px">Uppgifter</h5>
+            <ul>
+              <li>Icon: 44px (smaller than Styr)</li>
+              <li>Title: "Inga X <em>matchar</em>" — implies filter context, but…</li>
+              <li>…no way to clear the filters from here</li>
+              <li>Body CTA: <strong>none</strong> — must move to toolbar</li>
+            </ul>
+            <span class="tag bad">Mixed truly-empty/filtered semantics</span>
+            <span class="tag bad">No body CTA</span>
+            <span class="tag bad">Icon smaller than peers</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Laglistor -->
+      <div class="audit-row">
+        <div class="audit-card">
+          <div class="surface">
+            <div class="surface__crumb">Bygg &amp; Fastighet AB &nbsp;›&nbsp; <strong>Laglistor</strong></div>
+            <div class="surface__head">
+              <div>
+                <h3>Laglistor</h3>
+                <p class="sub">Hantera dina listor och håll koll på relevanta rättsliga krav.</p>
+              </div>
+              <div class="actions">
+                <button class="btn">Skapa kontroll</button>
+                <button class="btn btn--primary">+ Lägg till dokument</button>
+              </div>
+            </div>
+            <div class="surface__toolbar">
+              <div class="surface__toolbar-left">
+                <span class="chip active">📖 Laglistor</span>
+                <span class="chip muted">⟳ Ändringar</span>
+              </div>
+              <div class="surface__toolbar-right">
+                <span class="chip">Huvudlista (0) ▾</span>
+                <span class="input">🔍 Sök dokument…</span>
+                <span class="chip">Filter</span>
+                <span class="chip">Efterlevnad ▾</span>
+                <span class="chip">⚙</span>
+              </div>
+            </div>
+            <div class="surface__body current-laglistor">
+              <div class="center">
+                <div class="icon-wrap">
+                  <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+                </div>
+                <p>Inga dokument i denna lista. Lägg till dokument för att komma igång.</p>
+              </div>
+            </div>
+          </div>
+          <div class="audit-meta">
+            <span class="badge-current">Current</span>
+            <h5 style="margin-top:8px">Laglistor</h5>
+            <ul>
+              <li>Icon: 44px, muted-bg circle</li>
+              <li>Title: <strong>missing entirely</strong></li>
+              <li>Body: one inline paragraph</li>
+              <li>Body CTA: <strong>none</strong></li>
+            </ul>
+            <span class="tag bad">No title</span>
+            <span class="tag bad">No body CTA</span>
+            <span class="tag bad">Smaller icon than Styr</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Kontroller -->
+      <div class="audit-row">
+        <div class="audit-card">
+          <div class="surface">
+            <div class="surface__crumb">Bygg &amp; Fastighet AB &nbsp;›&nbsp; Laglistor &nbsp;›&nbsp; <strong>Kontroller</strong></div>
+            <div class="surface__head">
+              <div>
+                <h3>Kontroller</h3>
+                <p class="sub">Hantera pågående och tidigare efterlevnadskontroller.</p>
+              </div>
+              <div class="actions">
+                <button class="btn btn--primary">+ Skapa kontroll</button>
+              </div>
+            </div>
+            <div class="surface__toolbar">
+              <div class="surface__toolbar-left">
+                <span class="chip active">Aktiva <span class="count">0</span></span>
+                <span class="chip muted">Slutförda <span class="count">0</span></span>
+                <span class="chip muted">Alla <span class="count">0</span></span>
+              </div>
+            </div>
+            <div class="surface__body current-kontroller">
+              <div class="center">
+                <p>Du har inga aktiva kontroller just nu.</p>
+                <button class="btn btn--primary btn--sm">+ Skapa kontroll</button>
+              </div>
+            </div>
+          </div>
+          <div class="audit-meta">
+            <span class="badge-current">Current</span>
+            <h5 style="margin-top:8px">Kontroller</h5>
+            <ul>
+              <li>Icon: <strong>missing entirely</strong></li>
+              <li>Title voice: "Du har inga X just nu"</li>
+              <li>Body CTA: primary only</li>
+            </ul>
+            <span class="tag bad">No icon</span>
+            <span class="tag bad">Different title voice</span>
+            <span class="tag bad">No secondary CTA (e.g. mall)</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Filer -->
+      <div class="audit-row">
+        <div class="audit-card">
+          <div class="surface">
+            <div class="surface__crumb">Bygg &amp; Fastighet AB &nbsp;›&nbsp; <strong>Filer</strong></div>
+            <div class="surface__head">
+              <div>
+                <h3>Filer</h3>
+                <p class="sub">Hantera och organisera filer för din organisation.</p>
+              </div>
+              <div class="actions">
+                <button class="btn">📂 Ny mapp</button>
+                <button class="btn btn--primary">⬆ Ladda upp</button>
+              </div>
+            </div>
+            <div class="surface__toolbar">
+              <div class="surface__toolbar-left">
+                <span class="input">🔍 Sök filer…</span>
+              </div>
+              <div class="surface__toolbar-right">
+                <span class="chip">Senaste ▾</span>
+                <span class="chip">Alla kategorier ▾</span>
+                <span class="chip">Alla… ▾</span>
+                <span class="chip">▦ Välj</span>
+                <span class="chip active">▦</span>
+                <span class="chip muted">≡</span>
+              </div>
+            </div>
+            <div class="surface__body current-filer">
+              <div class="center">
+                <div class="icon-wrap">
+                  <svg viewBox="0 0 24 24" width="40" height="40" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+                </div>
+                <h4>Tom mapp</h4>
+                <p>Ladda upp filer eller skapa en ny mapp för att komma igång.</p>
+                <button class="btn btn--primary btn--sm">⬆ Ladda upp filer</button>
+              </div>
+            </div>
+          </div>
+          <div class="audit-meta">
+            <span class="badge-current">Current</span>
+            <h5 style="margin-top:8px">Filer</h5>
+            <ul>
+              <li>Icon: 56px, <strong>no rounded muted-bg</strong></li>
+              <li>Title: "Tom mapp" — describes a state, not the entity</li>
+              <li>Body CTA: primary only (missing "Ny mapp")</li>
+            </ul>
+            <span class="tag bad">Title is the state, not the entity</span>
+            <span class="tag bad">No bg on icon → looks loose</span>
+            <span class="tag bad">Single CTA when toolbar offers two</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============================================================ -->
+    <!-- SECTION 2 — Diagnosis                                         -->
+    <!-- ============================================================ -->
+    <section class="section">
+      <h2>2 — Three things to fix</h2>
+      <p class="lede">
+        The chrome around the empty area (toolbar, breadcrumb, page title) is
+        already consistent. The empty state itself isn't.
+      </p>
+      <div class="principles">
+        <div class="principle">
+          <span class="pnum">01</span>
+          <h5>One anatomy, one voice</h5>
+          <p>
+            Every empty list uses the same icon container (56 × 56, rounded muted),
+            the same title voice ("Inga {entity} ännu"), and renders Safiro 500 on
+            the title. No more "Tom mapp" / "Du har inga X just nu" / missing titles.
+          </p>
+        </div>
+        <div class="principle">
+          <span class="pnum">02</span>
+          <h5>Body CTAs mirror the toolbar's primary action</h5>
+          <p>
+            If the toolbar has a primary + secondary, the empty state mirrors both.
+            Power users still skip the empty state and use the toolbar — keep both.
+            "Ny X" is primary; "Importera" / "Mall" is secondary.
+          </p>
+        </div>
+        <div class="principle">
+          <span class="pnum">03</span>
+          <h5>Truly-empty ≠ filtered-empty</h5>
+          <p>
+            Filtered-empty (filters applied, no matches) gets a softer treatment:
+            dashed-border icon, "Inga X matchar dina filter", and a "Rensa filter"
+            primary action. Create-flow CTA stays available but secondary.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============================================================ -->
+    <!-- SECTION 3 — The primitive                                     -->
+    <!-- ============================================================ -->
+    <section class="section">
+      <h2>3 — The primitive (already exists)</h2>
+      <p class="lede">
+        <code>components/ui/empty-state.tsx</code> is already in the repo but
+        unevenly adopted. Below: its anatomy + two render modes.
+      </p>
+
+      <div class="anatomy">
+        <div class="anatomy__demo">
+          <div>
+            <div class="section-label"><span class="badge-after">After</span> Truly empty (first-run)</div>
+            <div class="surface" style="min-height:300px">
+              <div class="surface__body">
+                <div class="empty">
+                  <div class="empty__icon icon-lg">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+                  </div>
+                  <div class="empty__text">
+                    <h4 class="empty__title">Inga styrdokument ännu</h4>
+                    <p class="empty__sub">Kom igång genom att skapa ett nytt styrdokument eller importera ett befintligt.</p>
+                  </div>
+                  <div class="empty__actions">
+                    <button class="btn btn--primary btn--sm"><svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>Nytt dokument</button>
+                    <button class="btn btn--sm"><svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M17 8l-5-5-5 5M12 3v12"/></svg>Importera</button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="section-label"><span class="badge-after">After</span> Filtered empty (no matches)</div>
+            <div class="surface" style="min-height:300px">
+              <div class="surface__body">
+                <div class="empty filtered">
+                  <div class="empty__icon icon-md">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+                  </div>
+                  <div class="empty__text">
+                    <h4 class="empty__title">Inga uppgifter matchar dina filter</h4>
+                    <p class="empty__sub">Justera filtren ovan eller börja om för att se alla uppgifter.</p>
+                  </div>
+                  <div class="empty__actions">
+                    <button class="btn btn--primary btn--sm">Rensa filter</button>
+                    <button class="btn btn--sm">+ Ny uppgift</button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="anatomy__notes">
+          <h4>API</h4>
+          <ul>
+            <li><code>icon</code> — lucide icon, wrapped in <code>EmptyState.Icon</code></li>
+            <li><code>title</code> — "Inga {entity} ännu" (Safiro 500, 17px)</li>
+            <li><code>description</code> — one sentence, action-oriented</li>
+            <li><code>action</code> — JSX (one or two buttons)</li>
+            <li><code>variant</code> — <code>'empty'</code> (default) | <code>'filtered'</code></li>
+          </ul>
+          <h4>Title-voice rules</h4>
+          <ul>
+            <li>Truly empty → <code>Inga {entity} ännu</code></li>
+            <li>Filtered → <code>Inga {entity} matchar dina filter</code></li>
+            <li>Never: "Tom mapp", "Du har inga X just nu"</li>
+          </ul>
+          <h4>CTA rules</h4>
+          <ul>
+            <li>Truly empty → mirror the toolbar's primary (+ secondary if it exists)</li>
+            <li>Filtered → primary "Rensa filter", secondary preserves the create flow</li>
+            <li>Toolbar buttons stay either way</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============================================================ -->
+    <!-- SECTION 4 — Unified after                                     -->
+    <!-- ============================================================ -->
+    <section class="section">
+      <h2>4 — Five pages, after</h2>
+      <p class="lede">
+        Same five pages with the unified empty state. The toolbar chrome above
+        each surface is unchanged — only the body differs.
+      </p>
+
+      <div class="unified-grid">
+        <!-- Styrdokument -->
+        <div>
+          <div class="section-label"><span class="badge-after">After</span> Styrdokument</div>
+          <div class="surface">
+            <div class="surface__head">
+              <div><h3>Styrdokument</h3><p class="sub">Policyer, rutiner och instruktioner</p></div>
+              <div class="actions">
+                <button class="btn">Importera</button>
+                <button class="btn btn--primary">+ Nytt dokument</button>
+              </div>
+            </div>
+            <div class="surface__body">
+              <div class="empty">
+                <div class="empty__icon icon-lg">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+                </div>
+                <div class="empty__text">
+                  <h4 class="empty__title">Inga styrdokument ännu</h4>
+                  <p class="empty__sub">Skapa ditt första styrdokument från grunden eller importera en befintlig version.</p>
+                </div>
+                <div class="empty__actions">
+                  <button class="btn btn--primary btn--sm">+ Nytt dokument</button>
+                  <button class="btn btn--sm">Importera</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Uppgifter (truly empty case) -->
+        <div>
+          <div class="section-label"><span class="badge-after">After</span> Uppgifter (inga uppgifter alls)</div>
+          <div class="surface">
+            <div class="surface__head">
+              <div><h3>Uppgifter</h3><p class="sub">Efterlevnadsuppgifter för organisationen</p></div>
+              <div class="actions"><button class="btn btn--primary">+ Ny uppgift</button></div>
+            </div>
+            <div class="surface__body">
+              <div class="empty">
+                <div class="empty__icon icon-lg">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M8 10h8M8 14h6"/></svg>
+                </div>
+                <div class="empty__text">
+                  <h4 class="empty__title">Inga uppgifter ännu</h4>
+                  <p class="empty__sub">Skapa en uppgift för att börja planera och spåra arbetet med er efterlevnad.</p>
+                </div>
+                <div class="empty__actions">
+                  <button class="btn btn--primary btn--sm">+ Ny uppgift</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Laglistor -->
+        <div>
+          <div class="section-label"><span class="badge-after">After</span> Laglistor</div>
+          <div class="surface">
+            <div class="surface__head">
+              <div><h3>Laglistor</h3><p class="sub">Lagar och krav som rör verksamheten</p></div>
+              <div class="actions">
+                <button class="btn">Skapa kontroll</button>
+                <button class="btn btn--primary">+ Lägg till dokument</button>
+              </div>
+            </div>
+            <div class="surface__body">
+              <div class="empty">
+                <div class="empty__icon icon-lg">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+                </div>
+                <div class="empty__text">
+                  <h4 class="empty__title">Inga dokument i listan ännu</h4>
+                  <p class="empty__sub">Lägg till relevanta regelverk eller importera en befintlig laglista för att komma igång.</p>
+                </div>
+                <div class="empty__actions">
+                  <button class="btn btn--primary btn--sm">+ Lägg till dokument</button>
+                  <button class="btn btn--sm">Importera laglista</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Kontroller -->
+        <div>
+          <div class="section-label"><span class="badge-after">After</span> Kontroller</div>
+          <div class="surface">
+            <div class="surface__head">
+              <div><h3>Kontroller</h3><p class="sub">Pågående och tidigare efterlevnadskontroller</p></div>
+              <div class="actions"><button class="btn btn--primary">+ Skapa kontroll</button></div>
+            </div>
+            <div class="surface__body">
+              <div class="empty">
+                <div class="empty__icon icon-lg">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><polyline points="20 6 9 17 4 12"/></svg>
+                </div>
+                <div class="empty__text">
+                  <h4 class="empty__title">Inga kontroller ännu</h4>
+                  <p class="empty__sub">Skapa en efterlevnadskontroll för att visa att ni faktiskt lever upp till lagkraven — och få en delbar rapport på köpet.</p>
+                </div>
+                <div class="empty__actions">
+                  <button class="btn btn--primary btn--sm">+ Skapa kontroll</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Filer -->
+        <div>
+          <div class="section-label"><span class="badge-after">After</span> Filer</div>
+          <div class="surface">
+            <div class="surface__head">
+              <div><h3>Filer</h3><p class="sub">Lagra och organisera filer för organisationen</p></div>
+              <div class="actions">
+                <button class="btn">+ Ny mapp</button>
+                <button class="btn btn--primary">⬆ Ladda upp</button>
+              </div>
+            </div>
+            <div class="surface__body">
+              <div class="empty">
+                <div class="empty__icon icon-lg">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+                </div>
+                <div class="empty__text">
+                  <h4 class="empty__title">Inga filer ännu</h4>
+                  <p class="empty__sub">Ladda upp filer eller skapa en mapp för att börja organisera era dokument.</p>
+                </div>
+                <div class="empty__actions">
+                  <button class="btn btn--primary btn--sm">⬆ Ladda upp filer</button>
+                  <button class="btn btn--sm">+ Ny mapp</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============================================================ -->
+    <!-- SECTION 5 — Filtered-empty variant                            -->
+    <!-- ============================================================ -->
+    <section class="section">
+      <h2>5 — Filtered empty (the other half)</h2>
+      <p class="lede">
+        When data exists but filters return zero rows, the empty state has a
+        different job: tell the user why they see nothing, and let them recover in
+        one click. Same primitive, <code>variant="filtered"</code>.
+      </p>
+      <div class="filtered-grid">
+        <!-- Uppgifter filtered -->
+        <div>
+          <div class="section-label"><span class="badge-after">After</span> Uppgifter (filter aktiva)</div>
+          <div class="surface">
+            <div class="surface__head">
+              <div><h3>Uppgifter</h3><p class="sub">23 uppgifter totalt · 0 matchar filtren</p></div>
+              <div class="actions"><button class="btn btn--primary">+ Ny uppgift</button></div>
+            </div>
+            <div class="surface__toolbar">
+              <div class="surface__toolbar-left">
+                <span class="chip active">Status: Pågående ×</span>
+                <span class="chip active">Prioritet: Hög ×</span>
+                <span class="chip active">Förfaller: Denna vecka ×</span>
+              </div>
+            </div>
+            <div class="surface__body">
+              <div class="empty filtered">
+                <div class="empty__icon icon-md">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+                </div>
+                <div class="empty__text">
+                  <h4 class="empty__title">Inga uppgifter matchar dina filter</h4>
+                  <p class="empty__sub">3 filter är aktiva. Rensa dem för att se alla uppgifter, eller skapa en ny direkt.</p>
+                </div>
+                <div class="empty__actions">
+                  <button class="btn btn--primary btn--sm">Rensa filter</button>
+                  <button class="btn btn--sm">+ Ny uppgift</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Filer filtered -->
+        <div>
+          <div class="section-label"><span class="badge-after">After</span> Filer (sökning utan träffar)</div>
+          <div class="surface">
+            <div class="surface__head">
+              <div><h3>Filer</h3><p class="sub">418 filer · 0 matchar "miljöplan 2024"</p></div>
+              <div class="actions">
+                <button class="btn">+ Ny mapp</button>
+                <button class="btn btn--primary">⬆ Ladda upp</button>
+              </div>
+            </div>
+            <div class="surface__body">
+              <div class="empty filtered">
+                <div class="empty__icon icon-md">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+                </div>
+                <div class="empty__text">
+                  <h4 class="empty__title">Inga filer matchar "miljöplan 2024"</h4>
+                  <p class="empty__sub">Pröva en annan sökterm eller rensa filtren för att se alla filer.</p>
+                </div>
+                <div class="empty__actions">
+                  <button class="btn btn--primary btn--sm">Rensa sökning</button>
+                  <button class="btn btn--sm">⬆ Ladda upp ny fil</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============================================================ -->
+    <!-- SECTION 6 — Migration                                         -->
+    <!-- ============================================================ -->
+    <section class="section">
+      <h2>6 — How the rollout would land</h2>
+      <p class="lede">
+        Mechanically small. The primitive already exists; the work is mostly
+        copy + replacing one-off divs with <code>&lt;EmptyState&gt;</code>.
+      </p>
+      <ul style="max-width:760px; color:hsl(var(--muted-foreground)); font-size:14px;">
+        <li>1. Add <code>variant: 'empty' | 'filtered'</code> to <code>EmptyState</code>; introduce the dashed-border icon style for filtered.</li>
+        <li>2. Codify title-voice rules in a tiny copy doc (or as inline JSDoc on the primitive) so reviewers catch deviations.</li>
+        <li>3. Replace the bespoke empty markup on the five surfaces with <code>&lt;EmptyState&gt;</code> calls. Each page already has the data needed to choose <code>empty</code> vs <code>filtered</code> (filter state).</li>
+        <li>4. Audit pass: grep for any remaining "Tom mapp" / "Du har inga X just nu" / titleless paragraphs.</li>
+      </ul>
+      <p style="margin-top:20px; color:hsl(var(--muted-foreground)); font-size:13px;">
+        Estimated effort: half a day for the primitive + per-page swap, plus
+        copy review for each Swedish string. Could ride along the next epic-22
+        consistency story.
+      </p>
+    </section>
+  </div>
+</body>
+</html>

--- a/_prototypes/law-item-timeline-panel.html
+++ b/_prototypes/law-item-timeline-panel.html
@@ -444,7 +444,7 @@
   .ai-toggle svg { width: 11px; height: 11px; color: hsl(214 80% 75%); }
   .ai-toggle .chev { width: 11px; height: 11px; color: hsl(var(--muted-foreground)); transition: transform 200ms; }
   .ai-toggle--open .chev { transform: rotate(180deg); }
-  .ai-inline { margin-top: 10px; padding: 12px 14px; border-radius: 8px; background: hsl(0 0% 12%); border-left: 2px solid hsl(214 60% 45%); font-size: 12.5px; line-height: 1.55; color: hsl(0 0% 80%); }
+  .ai-inline { margin-top: 10px; padding: 12px 14px; border-radius: 8px; background: hsl(0 0% 11%); border: 1px solid hsl(var(--border)); font-size: 12.5px; line-height: 1.6; color: hsl(0 0% 80%); }
 
   /* Variant D — right-panel snabblänk */
   .ai-snab { background: hsl(var(--card)); border: 1px solid hsl(var(--border)); border-radius: 10px; padding: 14px; position: absolute; right: 16px; top: 16px; width: 220px; }

--- a/_prototypes/law-item-timeline-panel.html
+++ b/_prototypes/law-item-timeline-panel.html
@@ -372,6 +372,97 @@
   .callout.ok strong { color: hsl(var(--t-success-fg)); }
 
   @media (max-width: 900px) { .scene { padding: 12px; } .modal { width: 100%; height: calc(100vh - 130px); } .callouts { grid-template-columns: 1fr; } }
+
+  /* ==================================================================
+     AI-sammanfattning packaging variants — 2026-05-21
+     Goal: today the AI summary is a giant blue block that dwarfs the
+     action surface below it. Show four discreet alternatives so we can
+     pick one rather than letting the current treatment stand by default.
+     ================================================================== */
+  .ai-section { max-width: min(94vw, 1240px); margin: 48px auto 0; padding: 0 4px; }
+  .ai-section__head { margin-bottom: 20px; }
+  .ai-section__head h2 { margin: 0 0 6px; font-size: 22px; letter-spacing: -0.01em; color: hsl(var(--foreground)); }
+  .ai-section__head p { margin: 0; font-size: 13.5px; color: hsl(var(--muted-foreground)); max-width: 720px; line-height: 1.55; }
+  .ai-tag { display: inline-flex; align-items: center; justify-content: center; min-width: 22px; height: 22px; padding: 0 7px; border-radius: 5px; background: hsl(var(--accent)); color: hsl(var(--muted-foreground)); font-size: 11px; font-weight: 600; letter-spacing: .04em; text-transform: uppercase; margin-right: 8px; }
+  .ai-tag--current { background: hsl(214 30% 22%); color: hsl(214 80% 75%); }
+  .ai-tag--rec { background: hsl(152 30% 18%); color: hsl(152 70% 70%); }
+
+  /* Reference (current) — the giant blue block */
+  .ai-ref { border: 1px solid hsl(var(--border)); border-radius: 12px; background: hsl(var(--card)); padding: 18px 18px 20px; margin-bottom: 28px; }
+  .ai-ref h3 { margin: 0 0 12px; font-size: 13px; letter-spacing: .04em; text-transform: uppercase; color: hsl(var(--muted-foreground)); display: flex; align-items: center; }
+  .ai-mock { background: hsl(var(--background)); border-radius: 8px; padding: 16px 18px; }
+  .ai-mock__title { font-family: var(--font-display); font-weight: 500; font-size: 19px; margin: 0 0 10px; letter-spacing: -0.005em; }
+  .ai-mock__badges { display: flex; gap: 6px; margin-bottom: 14px; flex-wrap: wrap; align-items: center; }
+  .ai-mock__pill { display: inline-flex; align-items: center; gap: 4px; padding: 2px 8px; border-radius: 999px; font-size: 11.5px; }
+  .ai-mock__pill .dot { width: 6px; height: 6px; border-radius: 999px; background: currentColor; opacity: .7; }
+  .ai-mock__pill--status { background: hsl(0 0% 17%); color: hsl(0 0% 80%); }
+  .ai-mock__pill--prio { background: hsl(var(--t-warning-bg)); color: hsl(var(--t-warning-fg)); }
+  .ai-mock__group { display: flex; align-items: center; gap: 8px; padding: 9px 0; border-top: 1px solid hsl(var(--border)); font-size: 11px; letter-spacing: .08em; text-transform: uppercase; color: hsl(var(--muted-foreground)); }
+  .ai-mock__group .line { flex: 1; height: 1px; background: hsl(var(--border)); }
+  .ai-mock__group .chev { width: 14px; height: 14px; color: hsl(var(--muted-foreground)); }
+
+  /* Today's giant block */
+  .ai-blob {
+    border: 1px solid hsl(214 40% 35%);
+    background: hsl(214 30% 14%);
+    color: hsl(214 80% 86%);
+    border-left: 3px solid hsl(214 80% 60%);
+    border-radius: 8px;
+    padding: 14px 16px;
+    margin-bottom: 16px;
+    font-size: 12.5px;
+    line-height: 1.55;
+  }
+  .ai-blob strong { color: hsl(214 90% 90%); }
+
+  /* Variants grid */
+  .ai-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 18px; }
+  @media (max-width: 980px) { .ai-grid { grid-template-columns: 1fr; } }
+  .ai-card { border: 1px solid hsl(var(--border)); border-radius: 12px; background: hsl(var(--card)); padding: 18px; display: flex; flex-direction: column; gap: 14px; }
+  .ai-card__head { display: flex; align-items: center; gap: 4px; }
+  .ai-card__head h3 { margin: 0; font-size: 14.5px; font-weight: 500; color: hsl(var(--foreground)); }
+  .ai-card__head .rec-tag { margin-left: 6px; }
+  .ai-card__body { background: hsl(var(--background)); border-radius: 8px; padding: 16px; min-height: 220px; position: relative; }
+  .ai-card__notes { font-size: 12.5px; color: hsl(var(--muted-foreground)); line-height: 1.55; margin: 0; }
+  .ai-card__notes b { color: hsl(0 0% 80%); font-weight: 500; }
+
+  /* Variant B — AI sparkle chip + popover */
+  .ai-spark-chip { display: inline-flex; align-items: center; gap: 5px; padding: 2px 8px 2px 6px; border-radius: 999px; font-size: 11.5px; color: hsl(214 80% 80%); background: hsl(214 30% 18%); border: 1px solid hsl(214 40% 30%); cursor: default; }
+  .ai-spark-chip svg { width: 12px; height: 12px; }
+  .ai-popover { position: absolute; top: 56px; left: 16px; right: 16px; background: hsl(var(--popover)); border: 1px solid hsl(var(--border)); border-radius: 10px; padding: 12px 14px; box-shadow: 0 12px 28px hsl(0 0% 0% / 0.55); }
+  .ai-popover__hd { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; }
+  .ai-popover__hd .lbl { font-size: 10.5px; letter-spacing: .08em; text-transform: uppercase; color: hsl(var(--muted-foreground)); display: inline-flex; align-items: center; gap: 5px; }
+  .ai-popover__hd .lbl svg { width: 11px; height: 11px; color: hsl(214 80% 75%); }
+  .ai-popover__body { font-size: 12.5px; line-height: 1.6; color: hsl(0 0% 80%); max-height: 130px; overflow: hidden; position: relative; }
+  .ai-popover__body::after { content: ''; position: absolute; left: 0; right: 0; bottom: 0; height: 32px; background: linear-gradient(180deg, transparent, hsl(var(--popover))); pointer-events: none; }
+  .ai-popover__foot { display: flex; justify-content: flex-end; margin-top: 8px; }
+  .ai-popover__more { background: none; border: 0; padding: 0; color: hsl(214 80% 80%); font-size: 12px; cursor: pointer; }
+
+  /* Variant C — collapsible inline */
+  .ai-toggle { display: inline-flex; align-items: center; gap: 6px; padding: 3px 9px; border-radius: 6px; background: transparent; border: 1px dashed hsl(var(--border)); color: hsl(var(--muted-foreground)); font-size: 11.5px; cursor: default; transition: background 120ms; }
+  .ai-toggle:hover { background: hsl(var(--accent)); color: hsl(var(--foreground)); }
+  .ai-toggle svg { width: 11px; height: 11px; color: hsl(214 80% 75%); }
+  .ai-toggle .chev { width: 11px; height: 11px; color: hsl(var(--muted-foreground)); transition: transform 200ms; }
+  .ai-toggle--open .chev { transform: rotate(180deg); }
+  .ai-inline { margin-top: 10px; padding: 12px 14px; border-radius: 8px; background: hsl(0 0% 12%); border-left: 2px solid hsl(214 60% 45%); font-size: 12.5px; line-height: 1.55; color: hsl(0 0% 80%); }
+
+  /* Variant D — right-panel snabblänk */
+  .ai-snab { background: hsl(var(--card)); border: 1px solid hsl(var(--border)); border-radius: 10px; padding: 14px; position: absolute; right: 16px; top: 16px; width: 220px; }
+  .ai-snab h4 { margin: 0 0 10px; font-size: 11px; letter-spacing: .08em; text-transform: uppercase; color: hsl(var(--muted-foreground)); }
+  .ai-snab__item { display: flex; align-items: center; gap: 8px; padding: 7px 9px; border-radius: 6px; background: hsl(0 0% 12%); font-size: 12px; color: hsl(0 0% 82%); margin-bottom: 4px; border: 1px solid transparent; }
+  .ai-snab__item--ai { color: hsl(214 80% 80%); border-color: hsl(214 30% 28%); background: hsl(214 25% 13%); }
+  .ai-snab__item svg { width: 13px; height: 13px; flex-shrink: 0; }
+
+  /* Variant D — left side mini-modal scaled down so right rail fits */
+  .ai-card--with-rail .ai-card__body { padding-right: 250px; }
+
+  /* Variant A — minimal title area */
+  .ai-empty-note { margin-top: 16px; padding: 10px 12px; border-radius: 6px; border: 1px dashed hsl(var(--border)); color: hsl(var(--muted-foreground)); font-size: 11.5px; }
+
+  @media (max-width: 720px) {
+    .ai-card--with-rail .ai-card__body { padding-right: 16px; }
+    .ai-snab { position: static; width: 100%; margin-top: 14px; }
+  }
 </style>
 </head>
 <body>
@@ -754,6 +845,193 @@
   <div class="callout"><strong>2 · En typ-signal</strong>Ikonbrickan bär typ, pillret bär utfall, och tidslinjens prick är en neutral trådmarkör. Prova "Kompakt vy" (ikonen i panelhuvudet) för tätare rader.</div>
   <div class="callout ok"><strong>3 · Gles vy</strong>Växla "Innehåll → Ny lag" uppe till vänster för att se hur en nyss tillagd lag ser ut: bara startpunkten + en vänlig instruktion.</div>
 </div>
+
+<!-- ============================================================== -->
+<!-- AI-sammanfattning packaging variants                            -->
+<!-- ============================================================== -->
+<section class="ai-section">
+  <header class="ai-section__head">
+    <h2 class="font-safiro">Packaging the AI-sammanfattning</h2>
+    <p>
+      Today the AI-sammanfattning is rendered as a tall blue callout
+      between the title and the section accordions — visually the heaviest
+      thing in the modal, even though it's background context rather than
+      something the user needs to act on. Four ways to make it
+      discreet-by-default while keeping it one click away.
+    </p>
+  </header>
+
+  <!-- Today — for visual reference -->
+  <div class="ai-ref">
+    <h3><span class="ai-tag ai-tag--current">Idag</span>Hur det ser ut nu</h3>
+    <div class="ai-mock">
+      <h4 class="ai-mock__title">Arbetsmiljölag (1977:1160)</h4>
+      <div class="ai-mock__badges">
+        <span class="ai-mock__pill ai-mock__pill--status"><span class="dot"></span>Ej påbörjad</span>
+        <span class="ai-mock__pill ai-mock__pill--prio">⚑ Medel</span>
+      </div>
+      <div class="ai-blob">
+        <strong>AI-sammanfattning:</strong> Arbetsmiljölagen (AML, 1977:1160) är en ramlag som syftar till att förebygga ohälsa och olycksfall i arbetet samt att uppnå en god arbetsmiljö. Lagen gäller varje verksamhet där arbetstagare utför arbete för en arbetsgivares räkning och likställer även bland annat studerande och totalförsvarspliktiga med arbetstagare. Centrala bestämmelser rör arbetsgivarens skyldighet att bedriva systematiskt arbetsmiljöarbete, utreda arbetsskador, anpassa arbetsförhållandena till individuella förutsättningar… <em>(15 rader till)</em>
+      </div>
+      <div class="ai-mock__group"><span>EFTERLEVNAD</span><span class="line"></span><svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></div>
+      <div class="ai-mock__group"><span>REFERENS</span><span class="line"></span><svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></div>
+      <div class="ai-mock__group"><span>UPPGIFTER &amp; FILER</span><span class="line"></span><svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></div>
+    </div>
+  </div>
+
+  <!-- 4 variants -->
+  <div class="ai-grid">
+
+    <!-- A — Drop entirely -->
+    <article class="ai-card">
+      <header class="ai-card__head">
+        <span class="ai-tag">A</span>
+        <h3>Ta bort helt</h3>
+      </header>
+      <div class="ai-card__body">
+        <div class="ai-mock">
+          <h4 class="ai-mock__title">Arbetsmiljölag (1977:1160)</h4>
+          <div class="ai-mock__badges">
+            <span class="ai-mock__pill ai-mock__pill--status"><span class="dot"></span>Ej påbörjad</span>
+            <span class="ai-mock__pill ai-mock__pill--prio">⚑ Medel</span>
+          </div>
+          <div class="ai-mock__group"><span>EFTERLEVNAD</span><span class="line"></span><svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></div>
+          <div class="ai-mock__group"><span>REFERENS</span><span class="line"></span><svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></div>
+          <div class="ai-mock__group"><span>UPPGIFTER &amp; FILER</span><span class="line"></span><svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></div>
+          <div class="ai-empty-note">Användare som vill ha sammanfattning frågar Lexa direkt: "Sammanfatta lagen".</div>
+        </div>
+      </div>
+      <p class="ai-card__notes">
+        <b>Pro:</b> Maximalt fokus på det användaren ska göra (efterlevnad,
+        kravpunkter, uppgifter). En klick mindre att scrolla förbi.<br>
+        <b>Con:</b> Förlorar en snabb orientering för nyligen tillagda lagar
+        där användaren inte hunnit läsa sig in. Lexa-knappen finns kvar som
+        utväg men det är ett mer aktivt steg.
+      </p>
+    </article>
+
+    <!-- B — AI sparkle chip + popover -->
+    <article class="ai-card">
+      <header class="ai-card__head">
+        <span class="ai-tag">B</span>
+        <h3>Diskret AI-chip i badge-raden</h3>
+      </header>
+      <div class="ai-card__body">
+        <div class="ai-mock">
+          <h4 class="ai-mock__title">Arbetsmiljölag (1977:1160)</h4>
+          <div class="ai-mock__badges">
+            <span class="ai-mock__pill ai-mock__pill--status"><span class="dot"></span>Ej påbörjad</span>
+            <span class="ai-mock__pill ai-mock__pill--prio">⚑ Medel</span>
+            <span class="ai-spark-chip">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v2"/><path d="M12 19v2"/><path d="M5 12H3"/><path d="M21 12h-2"/><path d="M18.36 5.64l-1.41 1.41"/><path d="M7.05 16.95l-1.41 1.41"/><path d="M18.36 18.36l-1.41-1.41"/><path d="M7.05 7.05L5.64 5.64"/></svg>
+              Sammanfattning
+            </span>
+          </div>
+          <div class="ai-mock__group"><span>EFTERLEVNAD</span><span class="line"></span><svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></div>
+          <div class="ai-mock__group"><span>REFERENS</span><span class="line"></span><svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></div>
+          <div class="ai-mock__group"><span>UPPGIFTER &amp; FILER</span><span class="line"></span><svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></div>
+          <!-- Popover open (click state) -->
+          <div class="ai-popover">
+            <div class="ai-popover__hd">
+              <span class="lbl"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v2"/><path d="M12 19v2"/><path d="M5 12H3"/><path d="M21 12h-2"/></svg>AI-sammanfattning</span>
+            </div>
+            <div class="ai-popover__body">
+              Arbetsmiljölagen (AML, 1977:1160) är en ramlag som syftar till att förebygga ohälsa och olycksfall i arbetet samt att uppnå en god arbetsmiljö. Lagen gäller varje verksamhet där arbetstagare utför arbete för en arbetsgivares räkning…
+            </div>
+            <div class="ai-popover__foot">
+              <button class="ai-popover__more">Öppna i Lexa →</button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <p class="ai-card__notes">
+        <b>Pro:</b> Sammanfattningen är synligt tillgänglig (chipet säger
+        "den finns") men kostar bara en rad i badge-raden. Popover är fritt
+        skalbar — kort eller lång, alltid samma chrome.<br>
+        <b>Con:</b> Chip-pattern kan tappas i alla andra pills. Popover
+        läggs ovanpå innehållet snarare än vid sidan om.
+      </p>
+    </article>
+
+    <!-- C — Collapsible inline -->
+    <article class="ai-card">
+      <header class="ai-card__head">
+        <span class="ai-tag">C</span>
+        <h3>"Visa AI-sammanfattning ▾" — fällbar inline <span class="ai-tag ai-tag--rec rec-tag">Rekommenderad</span></h3>
+      </header>
+      <div class="ai-card__body">
+        <div class="ai-mock">
+          <h4 class="ai-mock__title">Arbetsmiljölag (1977:1160)</h4>
+          <div class="ai-mock__badges">
+            <span class="ai-mock__pill ai-mock__pill--status"><span class="dot"></span>Ej påbörjad</span>
+            <span class="ai-mock__pill ai-mock__pill--prio">⚑ Medel</span>
+            <span class="ai-toggle ai-toggle--open">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v2"/><path d="M12 19v2"/><path d="M5 12H3"/><path d="M21 12h-2"/></svg>
+              Visa AI-sammanfattning
+              <svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+            </span>
+          </div>
+          <div class="ai-inline">
+            Arbetsmiljölagen (AML, 1977:1160) är en ramlag som syftar till att förebygga ohälsa och olycksfall i arbetet samt att uppnå en god arbetsmiljö. Lagen gäller varje verksamhet där arbetstagare utför arbete för en arbetsgivares räkning…
+          </div>
+          <div class="ai-mock__group"><span>EFTERLEVNAD</span><span class="line"></span><svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></div>
+          <div class="ai-mock__group"><span>REFERENS</span><span class="line"></span><svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></div>
+        </div>
+      </div>
+      <p class="ai-card__notes">
+        <b>Pro:</b> Default-stängd → modalen öppnas direkt på det actionable.
+        Kompakt pill mellan badges. Fortfarande tydligt vad det är när
+        användaren vill ha det. Lägger noll vertikalt utrymme när stängd.<br>
+        <b>Con:</b> När öppen tar den fortfarande utrymme — men det är ett
+        aktivt val, inte default.
+      </p>
+    </article>
+
+    <!-- D — Right-panel Snabblänk -->
+    <article class="ai-card ai-card--with-rail">
+      <header class="ai-card__head">
+        <span class="ai-tag">D</span>
+        <h3>Flytta till Snabblänkar i högerpanelen</h3>
+      </header>
+      <div class="ai-card__body">
+        <div class="ai-mock">
+          <h4 class="ai-mock__title">Arbetsmiljölag (1977:1160)</h4>
+          <div class="ai-mock__badges">
+            <span class="ai-mock__pill ai-mock__pill--status"><span class="dot"></span>Ej påbörjad</span>
+            <span class="ai-mock__pill ai-mock__pill--prio">⚑ Medel</span>
+          </div>
+          <div class="ai-mock__group"><span>EFTERLEVNAD</span><span class="line"></span><svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></div>
+          <div class="ai-mock__group"><span>REFERENS</span><span class="line"></span><svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></div>
+          <div class="ai-mock__group"><span>UPPGIFTER &amp; FILER</span><span class="line"></span><svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></div>
+        </div>
+        <div class="ai-snab">
+          <h4>Snabblänkar</h4>
+          <div class="ai-snab__item">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+            Visa fullständig lag
+          </div>
+          <div class="ai-snab__item ai-snab__item--ai">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v2"/><path d="M12 19v2"/><path d="M5 12H3"/><path d="M21 12h-2"/><path d="M18.36 5.64l-1.41 1.41"/><path d="M7.05 16.95l-1.41 1.41"/></svg>
+            AI-sammanfattning
+          </div>
+          <div class="ai-snab__item">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4v13a3 3 0 0 0 3 3h7"/></svg>
+            Fråga Lexa om lagen
+          </div>
+        </div>
+      </div>
+      <p class="ai-card__notes">
+        <b>Pro:</b> Helt borta från huvudflödet. Hamnar bland övriga
+        "background context"-länkar där det semantiskt hör hemma.<br>
+        <b>Con:</b> Höger-panelen blir längre, och länken är mindre
+        upptäckbar än ett inline-element nära titeln. Klick öppnar troligen
+        en popover eller liten drawer — extra interaktion utan stor vinst
+        jämfört med variant C.
+      </p>
+    </article>
+  </div>
+</section>
+
 <div style="height: 36px;"></div>
 
 <script>

--- a/_prototypes/law-item-timeline-panel.html
+++ b/_prototypes/law-item-timeline-panel.html
@@ -1,0 +1,867 @@
+<!doctype html>
+<html lang="sv" class="dark">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Laglig · Tidslinje i lagmodalen (dark — v2)</title>
+<style>
+  /* ==================================================================
+     Fonts — Safiro (display, weight 500) + Google Sans Flex (body)
+     ================================================================== */
+  @font-face { font-family: 'Safiro'; src: url('../public/fonts/safiro-medium-webfont.woff2') format('woff2'), url('../public/fonts/safiro-medium-webfont.woff') format('woff'); font-weight: 500; font-style: normal; font-display: swap; }
+  @font-face { font-family: 'Google Sans Flex'; src: url('../public/fonts/GoogleSansFlex.ttf') format('truetype'); font-weight: 100 900; font-style: normal; font-display: swap; }
+
+  /* ==================================================================
+     Dark theme tokens — copied 1:1 from app/globals.css .dark
+     ================================================================== */
+  :root {
+    --background: 0 0% 10%; --foreground: 0 0% 93%; --card: 0 0% 9%;
+    --popover: 0 0% 14%; --primary: 0 0% 93%; --primary-foreground: 0 0% 10%;
+    --secondary: 0 0% 17%; --muted: 0 0% 17%; --muted-foreground: 0 0% 64%;
+    --accent: 0 0% 17%; --border: 0 0% 19%; --radius: 0.5rem;
+    --t-success-bg: 152 30% 18%; --t-success-fg: 152 70% 70%;
+    --t-warning-bg: 27 30% 18%;  --t-warning-fg: 38 80% 70%;
+    --t-danger-bg: 348 30% 20%;  --t-danger-fg: 350 80% 75%;
+    --t-info-bg: 224 30% 22%;    --t-info-fg: 214 90% 75%;
+    --gold: 40 45% 72%;
+    --font-sans: 'Google Sans Flex', system-ui, -apple-system, sans-serif;
+    --font-display: 'Safiro', 'Google Sans Flex', system-ui, sans-serif;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body { font-family: var(--font-sans); font-size: 14px; background: hsl(0 0% 6%); color: hsl(var(--foreground)); min-height: 100vh; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+  .font-safiro { font-family: var(--font-display); font-weight: 500; }
+
+  /* ---- Prototype chrome -------------------------------------------- */
+  .proto-bar { position: sticky; top: 0; z-index: 100; display: flex; align-items: center; gap: 16px; padding: 12px 22px; background: hsl(0 0% 8% / .82); backdrop-filter: blur(16px) saturate(140%); -webkit-backdrop-filter: blur(16px) saturate(140%); border-bottom: 1px solid hsl(var(--border)); color: hsl(0 0% 80%); font-size: 13px; flex-wrap: wrap; }
+  .proto-brand { display: flex; align-items: center; gap: 10px; font-size: 14px; color: hsl(0 0% 92%); }
+  .proto-brand .font-safiro { font-size: 15px; }
+  .proto-brand .dot { width: 6px; height: 6px; border-radius: 999px; background: hsl(var(--gold)); box-shadow: 0 0 12px hsl(var(--gold) / .7); }
+  .seg-group { display: flex; gap: 4px; padding: 4px; background: hsl(0 0% 13%); border: 1px solid hsl(var(--border)); border-radius: 999px; }
+  .seg-group button { appearance: none; background: transparent; border: 0; color: hsl(0 0% 62%); font: inherit; font-size: 12px; font-weight: 500; padding: 7px 13px; border-radius: 999px; cursor: pointer; transition: all 160ms ease; display: flex; align-items: center; gap: 7px; }
+  .seg-group button .k { font-size: 10px; padding: 2px 5px; border-radius: 4px; background: hsl(0 0% 20%); color: hsl(0 0% 60%); font-variant-numeric: tabular-nums; font-weight: 600; }
+  .seg-group button:hover { color: hsl(0 0% 92%); }
+  .seg-group button.active { background: hsl(0 0% 92%); color: hsl(0 0% 12%); }
+  .seg-group button.active .k { background: hsl(0 0% 12%); color: hsl(0 0% 92%); }
+  .proto-label { font-size: 11px; text-transform: uppercase; letter-spacing: .06em; color: hsl(0 0% 48%); }
+  .proto-spacer { margin-left: auto; }
+
+  /* ---- Scene ------------------------------------------------------- */
+  .scene { position: relative; min-height: calc(100vh - 51px); padding: 30px 40px 32px; display: flex; align-items: center; justify-content: center; }
+  .scene::after { content: ''; position: absolute; inset: 0; background: hsl(0 0% 3% / .55); pointer-events: none; }
+
+  /* ---- Modal shell ------------------------------------------------- */
+  .modal { position: relative; z-index: 1; width: min(94vw, 1240px); height: min(88vh, 880px); background: hsl(var(--background)); border: 1px solid hsl(var(--border)); border-radius: 12px; box-shadow: 0 30px 90px hsl(0 0% 0% / .55); display: flex; flex-direction: column; overflow: hidden; }
+  .modal-header { display: flex; align-items: center; gap: 10px; padding: 13px 18px; border-bottom: 1px solid hsl(var(--border)); flex-shrink: 0; min-height: 52px; }
+  .breadcrumb { font-size: 13.5px; color: hsl(var(--muted-foreground)); font-weight: 450; }
+  .breadcrumb a { color: inherit; text-decoration: none; transition: color 150ms; }
+  .breadcrumb a:hover { color: hsl(var(--foreground)); }
+  .header-actions { margin-left: auto; display: flex; align-items: center; gap: 2px; }
+  .icon-btn { appearance: none; background: transparent; border: 0; color: hsl(var(--muted-foreground)); width: 32px; height: 32px; border-radius: 7px; display: inline-flex; align-items: center; justify-content: center; cursor: pointer; transition: all 150ms ease; }
+  .icon-btn:hover { background: hsl(var(--muted)); color: hsl(var(--foreground)); }
+  .icon-btn svg { width: 16px; height: 16px; }
+  .lexa-mark { display: inline-flex; align-items: center; justify-content: center; flex-shrink: 0; color: hsl(var(--foreground)); }
+  .lexa-mark svg { width: 20px; height: 20px; }
+  .lexa-mark.sm svg { width: 15px; height: 15px; }
+  .lexa-mark.gold { color: hsl(var(--gold)); }
+
+  /* ---- State-3 strip ----------------------------------------------- */
+  .strip { max-height: 0; overflow: hidden; border-bottom: 1px solid transparent; transition: max-height 420ms cubic-bezier(.4,0,.2,1), border-color 220ms ease, padding 420ms cubic-bezier(.4,0,.2,1); background: hsl(var(--card)); padding: 0 22px; }
+  .state-3 .strip { max-height: 64px; border-bottom-color: hsl(var(--border)); padding: 12px 22px; }
+  .strip-inner { display: flex; align-items: center; gap: 14px; opacity: 0; transform: translateY(-4px); transition: opacity 240ms ease 180ms, transform 240ms ease 180ms; }
+  .state-3 .strip-inner { opacity: 1; transform: translateY(0); }
+  .strip-icon { width: 32px; height: 32px; border-radius: 8px; background: hsl(var(--muted)); display: inline-flex; align-items: center; justify-content: center; color: hsl(var(--muted-foreground)); flex-shrink: 0; }
+  .strip-title { font-weight: 600; font-size: 14px; color: hsl(var(--foreground)); }
+  .strip-meta { display: flex; gap: 8px; font-size: 12px; color: hsl(var(--muted-foreground)); align-items: center; }
+  .strip-return { margin-left: auto; appearance: none; background: transparent; border: 1px solid hsl(var(--border)); color: hsl(var(--foreground)); font: inherit; font-size: 12px; font-weight: 500; padding: 6px 12px; border-radius: 8px; cursor: pointer; display: inline-flex; align-items: center; gap: 6px; transition: all 150ms ease; }
+  .strip-return:hover { background: hsl(var(--muted)); }
+  .strip-return svg { width: 12px; height: 12px; }
+
+  /* ---- Body grid --------------------------------------------------- */
+  .modal-body { flex: 1; min-height: 0; display: flex; position: relative; }
+  .content-panel, .right-panel, .work-panel { flex-basis: 0; min-width: 0; overflow: hidden; position: relative; transition: flex-grow 480ms cubic-bezier(.4,0,.2,1), opacity 280ms ease; }
+  .content-panel { flex-grow: 3; }
+  .right-panel  { flex-grow: 2; border-left: 1px solid hsl(var(--border)); }
+  .work-panel   { flex-grow: 0; opacity: 0; border-left: 1px solid hsl(var(--border)); background: hsl(var(--card)); }
+  .state-2 .right-panel { flex-grow: 0; opacity: 0; }
+  .state-2 .work-panel  { flex-grow: 3; opacity: 1; }
+  .state-3 .content-panel { flex-grow: 0; opacity: 0; }
+  .state-3 .right-panel   { flex-grow: 0; opacity: 0; }
+  .state-3 .work-panel    { flex-grow: 1; opacity: 1; border-left: 0; background: hsl(var(--background)); }
+  .rail { width: 0; flex-shrink: 0; overflow: hidden; transition: width 480ms cubic-bezier(.4,0,.2,1); border-left: 1px solid transparent; background: hsl(var(--card)); }
+  .state-2 .rail { width: 44px; border-left-color: hsl(var(--border)); }
+
+  /* ---- LEFT CONTENT PANEL ------------------------------------------ */
+  .content-inner { height: 100%; overflow-y: auto; padding: 24px; scrollbar-width: thin; }
+  .content-inner::-webkit-scrollbar { width: 8px; }
+  .content-inner::-webkit-scrollbar-thumb { background: hsl(var(--border)); border-radius: 8px; }
+  .law-title { font-size: 20px; line-height: 1.2; letter-spacing: -0.01em; margin: 0 0 12px; color: hsl(var(--foreground)); }
+  .badge-row { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-bottom: 20px; }
+  .badge { display: inline-flex; align-items: center; gap: 6px; padding: 3px 9px; border-radius: 7px; font-size: 12px; font-weight: 500; border: 1px solid hsl(var(--border)); background: hsl(var(--muted) / .5); color: hsl(var(--foreground)); }
+  .badge .dot { width: 8px; height: 8px; border-radius: 999px; }
+  .badge.neutral .dot { background: hsl(215 15% 55%); }
+  .badge.warning { background: hsl(var(--t-warning-bg)); border-color: hsl(var(--t-warning-fg) / .25); color: hsl(var(--t-warning-fg)); }
+  .badge.warning svg { width: 12px; height: 12px; }
+  .toggle-all { margin-left: auto; }
+
+  .group-label { display: flex; width: 100%; align-items: center; gap: 12px; padding: 12px 4px 4px; cursor: pointer; user-select: none; appearance: none; background: transparent; border: 0; }
+  .group-label .gl-text { font-family: var(--font-display); font-weight: 500; font-size: 11px; text-transform: uppercase; letter-spacing: .08em; color: hsl(var(--muted-foreground)); transition: color 150ms; }
+  .group-label:hover .gl-text { color: hsl(var(--foreground)); }
+  .group-label .gl-line { height: 1px; flex: 1; background: hsl(var(--border)); }
+  .group-label .gl-count { display: inline-flex; height: 18px; min-width: 18px; align-items: center; justify-content: center; border-radius: 6px; background: hsl(var(--muted)); padding: 0 6px; font-size: 11px; font-weight: 600; font-variant-numeric: tabular-nums; color: hsl(var(--muted-foreground)); }
+  .group-label .gl-chev { width: 16px; height: 16px; color: hsl(var(--muted-foreground)); transition: transform 200ms ease; }
+  .group.collapsed .gl-chev { transform: rotate(-90deg); }
+  .group-content { display: flex; flex-direction: column; gap: 8px; padding-top: 8px; }
+  .group.collapsed .group-content { display: none; }
+
+  .acc { border: 1px solid hsl(var(--border)); border-radius: 9px; background: hsl(var(--card)); overflow: hidden; }
+  .acc-head { display: flex; align-items: center; gap: 10px; padding: 12px 14px; cursor: pointer; font-weight: 500; font-size: 13.5px; color: hsl(var(--foreground)); transition: background 150ms ease; user-select: none; }
+  .acc-head:hover { background: hsl(var(--muted) / .4); }
+  .acc-head .ico { width: 18px; height: 18px; color: hsl(var(--muted-foreground)); flex-shrink: 0; display: inline-flex; }
+  .acc-head .ico svg { width: 16px; height: 16px; }
+  .acc-head .mc { margin-left: auto; font-size: 12px; color: hsl(var(--muted-foreground)); font-weight: 450; }
+  .acc-head .chev { width: 16px; height: 16px; color: hsl(var(--muted-foreground)); transition: transform 200ms ease; flex-shrink: 0; }
+  .acc.closed .chev { transform: rotate(-90deg); }
+  .acc-body { padding: 0 14px 14px 42px; font-size: 13px; color: hsl(var(--muted-foreground)); line-height: 1.6; }
+  .acc.closed .acc-body { display: none; }
+
+  /* Aktivitet → now comments only (history lives in the timeline) */
+  .activity { margin-top: 18px; }
+  .activity h3 { font-size: 15px; font-weight: 600; color: hsl(var(--foreground)); margin: 0 0 12px; }
+  .comment-box { display: flex; align-items: center; gap: 10px; border: 1px solid hsl(var(--border)); border-radius: 9px; padding: 10px 13px; color: hsl(var(--muted-foreground)); cursor: text; }
+  .comment-box .cb { font-size: 13px; }
+  .act-promo { margin-top: 12px; border: 1px solid hsl(var(--border)); border-radius: 9px; padding: 12px 14px; display: flex; align-items: center; gap: 12px; background: hsl(var(--card)); }
+  .act-promo .ic { width: 34px; height: 34px; border-radius: 8px; background: hsl(var(--t-info-bg)); color: hsl(var(--t-info-fg)); display: inline-flex; align-items: center; justify-content: center; flex-shrink: 0; }
+  .act-promo .ic svg { width: 17px; height: 17px; }
+  .act-promo .txt { font-size: 12.5px; color: hsl(var(--muted-foreground)); line-height: 1.4; }
+  .act-promo .txt b { color: hsl(var(--foreground)); font-weight: 600; }
+  .act-promo button { margin-left: auto; }
+
+  /* ---- RIGHT PANEL ------------------------------------------------- */
+  .right-inner { height: 100%; overflow-y: auto; padding: 20px; display: flex; flex-direction: column; gap: 14px; }
+  .right-inner::-webkit-scrollbar { width: 6px; }
+  .right-inner::-webkit-scrollbar-thumb { background: hsl(var(--border)); border-radius: 6px; }
+  .card { border: 1px solid hsl(var(--border)); border-radius: 10px; background: hsl(var(--card)); padding: 16px 18px; }
+  .card h4 { margin: 0 0 14px; font-size: 15px; font-weight: 600; color: hsl(var(--foreground)); }
+  .field { display: flex; align-items: center; justify-content: space-between; padding: 8px 0; font-size: 13.5px; min-height: 32px; }
+  .field .k { color: hsl(var(--muted-foreground)); font-weight: 450; display: inline-flex; align-items: center; gap: 5px; }
+  .field .k svg { width: 13px; height: 13px; opacity: .6; }
+  .field .v { color: hsl(var(--foreground)); font-weight: 600; display: inline-flex; align-items: center; gap: 7px; }
+  .v-pill { padding: 4px 9px; border-radius: 7px; font-size: 12.5px; font-weight: 500; display: inline-flex; align-items: center; gap: 6px; border: 1px solid hsl(var(--border)); }
+  .v-pill.neutral { background: hsl(var(--muted) / .5); }
+  .v-pill.neutral .dot { width: 8px; height: 8px; border-radius: 999px; background: hsl(215 15% 55%); }
+  .v-pill.warning { background: hsl(var(--t-warning-bg)); color: hsl(var(--t-warning-fg)); border-color: hsl(var(--t-warning-fg) / .25); }
+  .v-pill .chev { width: 13px; height: 13px; opacity: .7; }
+  .v-muted { color: hsl(var(--muted-foreground)); font-weight: 400; }
+  .badge-ny { display: inline-flex; align-items: center; padding: 2px 8px; border-radius: 999px; background: hsl(var(--t-warning-bg)); color: hsl(var(--t-warning-fg)); font-size: 10.5px; font-weight: 600; }
+  .link-v { color: hsl(var(--foreground)); text-decoration: none; display: inline-flex; align-items: center; gap: 5px; }
+  .link-v svg { width: 12px; height: 12px; opacity: .6; }
+  .ql-list { display: flex; flex-direction: column; gap: 8px; }
+  .ql { appearance: none; font: inherit; font-size: 13.5px; font-weight: 500; width: 100%; text-align: left; padding: 10px 13px; border-radius: 8px; cursor: pointer; display: inline-flex; align-items: center; gap: 10px; transition: all 150ms ease; border: 1px solid hsl(var(--border)); background: transparent; color: hsl(var(--foreground)); }
+  .ql svg { width: 15px; height: 15px; color: hsl(var(--muted-foreground)); flex-shrink: 0; }
+  .ql:hover { background: hsl(var(--muted) / .5); }
+  .ql .ql-count { margin-left: auto; font-size: 11px; font-weight: 600; color: hsl(var(--muted-foreground)); background: hsl(var(--muted)); padding: 1px 7px; border-radius: 999px; }
+  .ql.solid { background: hsl(var(--foreground)); color: hsl(var(--background)); border-color: hsl(var(--foreground)); }
+  .ql.solid svg, .ql.solid .lexa-mark { color: hsl(var(--background)); }
+  .ql.solid:hover { background: hsl(var(--foreground) / .9); }
+  .overview-line { display: flex; align-items: center; gap: 9px; font-size: 13.5px; color: hsl(var(--muted-foreground)); }
+  .overview-line svg { width: 15px; height: 15px; }
+
+  /* ==================================================================
+     WORK PANEL — Timeline / Fråga Lexa
+     ================================================================== */
+  .work-panel { display: flex; flex-direction: column; }
+  .work-inner { display: flex; flex-direction: column; height: 100%; min-width: 0; }
+  .work-header { display: flex; align-items: center; gap: 10px; padding: 10px 14px; border-bottom: 1px solid hsl(var(--border)); flex-shrink: 0; min-height: 52px; }
+  .mode-seg { display: flex; gap: 3px; padding: 3px; background: hsl(var(--muted) / .7); border-radius: 9px; }
+  .mode-seg button { appearance: none; border: 0; background: transparent; font: inherit; font-size: 12.5px; font-weight: 500; color: hsl(var(--muted-foreground)); padding: 6px 12px; border-radius: 7px; cursor: pointer; transition: all 150ms ease; display: inline-flex; align-items: center; gap: 7px; }
+  .mode-seg button svg { width: 14px; height: 14px; }
+  .mode-seg button:hover { color: hsl(var(--foreground)); }
+  .mode-seg button.active { background: hsl(var(--background)); color: hsl(var(--foreground)); box-shadow: 0 1px 2px hsl(0 0% 0% / .35); }
+  .work-actions { margin-left: auto; display: flex; align-items: center; gap: 1px; }
+  .work-actions .divider { width: 1px; height: 18px; background: hsl(var(--border)); margin: 0 6px; }
+  .icon-btn.on { background: hsl(var(--muted)); color: hsl(var(--foreground)); }
+
+  .mode-pane { display: none; flex: 1; min-height: 0; flex-direction: column; }
+  .mode-pane.active { display: flex; }
+
+  /* filters — single scrollable row (no wrap) */
+  .tl-filterbar { display: flex; gap: 6px; padding: 11px 16px; flex-wrap: nowrap; overflow-x: auto; border-bottom: 1px solid hsl(var(--border)); flex-shrink: 0; scrollbar-width: none; }
+  .tl-filterbar::-webkit-scrollbar { display: none; }
+  .scene.sparse .tl-filterbar { display: none; }
+  .tl-filter { appearance: none; font: inherit; font-size: 12px; font-weight: 500; border: 1px solid hsl(var(--border)); background: transparent; color: hsl(var(--muted-foreground)); padding: 5px 11px; border-radius: 999px; cursor: pointer; transition: all 150ms ease; display: inline-flex; align-items: center; gap: 6px; white-space: nowrap; flex-shrink: 0; }
+  .tl-filter:hover { background: hsl(var(--muted) / .5); color: hsl(var(--foreground)); }
+  .tl-filter.active { background: hsl(var(--foreground)); color: hsl(var(--background)); border-color: hsl(var(--foreground)); }
+  .tl-filter .cnt { font-variant-numeric: tabular-nums; opacity: .6; }
+
+  .tl-body { flex: 1; min-height: 0; display: flex; position: relative; overflow: hidden; }
+  .tl-list { flex: 1; min-width: 0; overflow-y: auto; padding: 0 0 28px; scrollbar-width: thin; }
+  .tl-list::-webkit-scrollbar { width: 8px; }
+  .tl-list::-webkit-scrollbar-thumb { background: hsl(var(--border)); border-radius: 8px; }
+  .state-3 .tl-list { flex: 0 0 384px; border-right: 1px solid hsl(var(--border)); }
+
+  /* sparse-state hint (shown only when "Ny lag" content toggle is on) */
+  .tl-sparse-hint { display: none; flex-direction: column; gap: 6px; margin: 18px 16px 10px; padding: 16px; border: 1px dashed hsl(var(--border)); border-radius: 11px; background: hsl(var(--card)); }
+  .scene.sparse .tl-sparse-hint { display: flex; }
+  .tl-sparse-hint .sh-t { font-size: 13px; font-weight: 600; color: hsl(var(--foreground)); display: flex; align-items: center; gap: 8px; }
+  .tl-sparse-hint .sh-t svg { width: 15px; height: 15px; color: hsl(var(--t-info-fg)); }
+  .tl-sparse-hint .sh-h { font-size: 12.5px; color: hsl(var(--muted-foreground)); line-height: 1.5; }
+
+  /* "Kräver åtgärd" strip — open/actionable items, above the chronicle */
+  .tl-action-strip { padding: 14px 16px 6px; border-bottom: 1px solid hsl(var(--border)); margin-bottom: 4px; }
+  .scene.sparse .tl-action-strip { display: none; }
+  .tl-action-head { font-family: var(--font-display); font-size: 11px; font-weight: 500; letter-spacing: .08em; text-transform: uppercase; color: hsl(var(--t-warning-fg)); display: flex; align-items: center; gap: 8px; margin-bottom: 10px; padding-left: 2px; }
+  .tl-action-head .cnt { background: hsl(var(--t-warning-bg)); color: hsl(var(--t-warning-fg)); border-radius: 999px; padding: 1px 8px; font-size: 11px; }
+
+  .tl-month { font-family: var(--font-display); font-size: 11px; font-weight: 500; letter-spacing: .08em; text-transform: uppercase; color: hsl(var(--muted-foreground)); margin: 6px 0 10px 52px; padding-top: 6px; }
+  .scene.sparse .tl-month:not([data-keep]) { display: none; }
+
+  /* one continuous spine down the whole chronicle (months are side-markers,
+     not breaks). Lives on the stream wrapper so it spans every group. */
+  .tl-stream { position: relative; }
+  .tl-stream::before { content: ''; position: absolute; left: 28px; top: 34px; bottom: 16px; width: 2px; background: linear-gradient(to bottom, hsl(var(--border) / .25), hsl(var(--border)) 6%, hsl(var(--border)) 94%, hsl(var(--border) / .25)); }
+  .scene.sparse .tl-stream::before { display: none; }
+  .tl-track { position: relative; padding: 0 16px 0 52px; }
+  .scene.sparse .tl-track .tl-node:not([data-keep]) { display: none; }
+
+  .tl-node { position: relative; margin-bottom: 9px; cursor: pointer; border: 1px solid hsl(var(--border)); border-radius: 10px; background: hsl(var(--card)); padding: 14px 14px 13px; transition: all 150ms ease; }
+  .tl-node:hover { background: hsl(var(--muted) / .4); transform: translateX(1px); }
+  .tl-node.active { border-color: hsl(var(--gold) / .55); box-shadow: 0 0 0 2px hsl(var(--gold) / .14); }
+  /* (2) Single type-encoding: the rail dot is a NEUTRAL thread marker.
+         Type is carried by the icon tile; outcome by the verdict pill. */
+  .tl-track .tl-node::before { content: ''; box-sizing: border-box; position: absolute; left: -32px; top: 18px; width: 16px; height: 16px; border-radius: 999px; background: hsl(0 0% 38%); border: 3px solid hsl(var(--background)); box-shadow: 0 0 0 1px hsl(var(--border)); }
+  .tl-track .tl-node.active::before { background: hsl(var(--gold)); }
+
+  .tl-top { display: flex; align-items: flex-start; gap: 9px; }
+  .tl-kind { width: 25px; height: 25px; border-radius: 7px; flex-shrink: 0; display: inline-flex; align-items: center; justify-content: center; background: hsl(var(--muted)); color: hsl(var(--muted-foreground)); margin-top: 1px; }
+  .tl-kind svg { width: 14px; height: 14px; }
+  .t-amendment .tl-kind { background: hsl(var(--t-info-bg)); color: hsl(var(--t-info-fg)); }
+  .t-assessment .tl-kind { background: hsl(var(--t-success-bg)); color: hsl(var(--t-success-fg)); }
+  .t-action .tl-kind, .t-assessment-partial .tl-kind { background: hsl(var(--t-warning-bg)); color: hsl(var(--t-warning-fg)); }
+  .t-finding .tl-kind { background: hsl(var(--t-danger-bg)); color: hsl(var(--t-danger-fg)); }
+  .t-status .tl-kind { background: hsl(var(--t-success-bg)); color: hsl(var(--t-success-fg)); }
+
+  /* (7) eyebrow carries the TYPE, title carries the SUBJECT */
+  .tl-textcol { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 3px; }
+  .tl-eyebrow { font-family: var(--font-display); font-size: 10.5px; font-weight: 500; letter-spacing: .07em; text-transform: uppercase; color: hsl(var(--muted-foreground)); }
+  .tl-title { font-size: 13px; font-weight: 550; color: hsl(var(--foreground)); line-height: 1.3; }
+  .tl-date { font-size: 11.5px; color: hsl(var(--muted-foreground)); white-space: nowrap; margin-top: 1px; flex-shrink: 0; }
+  .tl-sub { margin: 7px 0 0 34px; font-size: 12.5px; color: hsl(var(--muted-foreground)); line-height: 1.5; }
+  .tl-tags { display: flex; gap: 6px; margin: 8px 0 0 34px; flex-wrap: wrap; align-items: center; }
+
+  /* (5) compact density — hide sub + tags, tighten */
+  .tl-list.compact .tl-sub, .tl-list.compact .tl-tags { display: none; }
+  .tl-list.compact .tl-node { padding: 8px 12px; margin-bottom: 5px; }
+  .tl-list.compact .tl-track .tl-node::before { top: 12px; }
+
+  /* (1) actionable node — left accent, no rail dot, action button */
+  .tl-actionable { border-left: 3px solid hsl(var(--t-warning-fg)); background: linear-gradient(to right, hsl(var(--t-warning-bg) / .4), transparent 60%); }
+  .tl-actionable .tl-cta { margin-left: auto; appearance: none; border: 0; font: inherit; font-size: 11.5px; font-weight: 600; padding: 4px 11px; border-radius: 7px; background: hsl(var(--t-warning-fg)); color: hsl(0 0% 10%); cursor: pointer; }
+
+  .verdict { display: inline-flex; align-items: center; gap: 5px; font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 999px; }
+  .verdict .vd { width: 6px; height: 6px; border-radius: 999px; }
+  .verdict.uppfylld { background: hsl(var(--t-success-bg)); color: hsl(var(--t-success-fg)); } .verdict.uppfylld .vd { background: hsl(var(--t-success-fg)); }
+  .verdict.delvis { background: hsl(var(--t-warning-bg)); color: hsl(var(--t-warning-fg)); } .verdict.delvis .vd { background: hsl(var(--t-warning-fg)); }
+  .verdict.ej { background: hsl(var(--t-danger-bg)); color: hsl(var(--t-danger-fg)); } .verdict.ej .vd { background: hsl(var(--t-danger-fg)); }
+  .verdict.info { background: hsl(var(--t-info-bg)); color: hsl(var(--t-info-fg)); } .verdict.info .vd { background: hsl(var(--t-info-fg)); }
+  .micro { display: inline-flex; align-items: center; gap: 5px; font-size: 11px; color: hsl(var(--muted-foreground)); background: hsl(var(--muted) / .7); padding: 2px 8px; border-radius: 999px; }
+  .micro svg { width: 11px; height: 11px; }
+  .micro.danger { background: hsl(var(--t-danger-bg)); color: hsl(var(--t-danger-fg)); }
+  .avatar-xs { width: 16px; height: 16px; border-radius: 999px; font-size: 9px; font-weight: 600; display: inline-flex; align-items: center; justify-content: center; color: #fff; background: hsl(214 45% 45%); }
+
+  /* detail */
+  .tl-detail { position: absolute; inset: 0; background: hsl(var(--card)); transform: translateX(100%); transition: transform 360ms cubic-bezier(.4,0,.2,1); display: flex; flex-direction: column; overflow: hidden; z-index: 4; }
+  .tl-body.detail-open .tl-detail { transform: translateX(0); box-shadow: -16px 0 36px hsl(0 0% 0% / .35); }
+  .state-3 .tl-detail { position: static; transform: none; flex: 1; box-shadow: none; min-width: 0; }
+  .state-3 .tl-body.detail-open .tl-detail { box-shadow: none; }
+  .detail-head { display: flex; align-items: center; gap: 10px; padding: 11px 16px; border-bottom: 1px solid hsl(var(--border)); flex-shrink: 0; }
+  .detail-back { appearance: none; border: 1px solid hsl(var(--border)); background: transparent; color: hsl(var(--foreground)); font: inherit; font-size: 12px; font-weight: 500; padding: 6px 11px; border-radius: 8px; cursor: pointer; display: inline-flex; align-items: center; gap: 6px; transition: all 150ms ease; }
+  .detail-back:hover { background: hsl(var(--muted) / .5); }
+  .detail-back svg { width: 12px; height: 12px; }
+  .state-3 .detail-back { display: none; }
+  .detail-head .dh { font-size: 13px; font-weight: 600; color: hsl(var(--foreground)); }
+  .detail-scroll { flex: 1; min-height: 0; overflow-y: auto; padding: 22px 22px 30px; scrollbar-width: thin; }
+  .state-3 .detail-scroll { padding: 28px 40px 36px; max-width: 760px; margin: 0 auto; width: 100%; }
+  .detail-scroll::-webkit-scrollbar { width: 8px; }
+  .detail-scroll::-webkit-scrollbar-thumb { background: hsl(var(--border)); border-radius: 8px; }
+  .detail-block { display: none; }
+  .detail-block.active { display: block; animation: fadeIn 260ms ease; }
+  @keyframes fadeIn { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: translateY(0); } }
+  .d-eyebrow { font-family: var(--font-display); display: flex; align-items: center; gap: 8px; font-size: 11.5px; font-weight: 500; letter-spacing: .07em; text-transform: uppercase; color: hsl(var(--muted-foreground)); margin-bottom: 10px; }
+  .d-eyebrow svg { width: 13px; height: 13px; }
+  .d-title { font-size: 21px; line-height: 1.2; letter-spacing: -0.01em; color: hsl(var(--foreground)); margin: 0 0 12px; }
+  .d-metarow { display: flex; gap: 14px; flex-wrap: wrap; align-items: center; margin: 0 0 20px; padding-bottom: 18px; border-bottom: 1px solid hsl(var(--border)); }
+  .d-meta { display: inline-flex; align-items: center; gap: 7px; font-size: 12.5px; color: hsl(var(--muted-foreground)); }
+  .d-meta .avatar-xs { width: 20px; height: 20px; font-size: 10px; }
+  .d-section { margin-bottom: 22px; }
+  .d-label { font-size: 12px; font-weight: 600; color: hsl(var(--foreground)); margin-bottom: 9px; display: flex; align-items: center; gap: 7px; }
+  .d-label svg { width: 13px; height: 13px; color: hsl(var(--muted-foreground)); }
+  .d-text { font-size: 13.5px; line-height: 1.65; color: hsl(var(--foreground)); }
+  .d-quote { border-left: 3px solid hsl(var(--border)); padding: 4px 0 4px 14px; font-size: 13.5px; line-height: 1.65; color: hsl(var(--foreground)); }
+  .krav-list { display: flex; flex-direction: column; gap: 7px; }
+  .krav { display: flex; align-items: center; gap: 10px; font-size: 13px; padding: 9px 12px; border: 1px solid hsl(var(--border)); border-radius: 9px; background: hsl(var(--background)); }
+  .krav .kbox { width: 18px; height: 18px; border-radius: 5px; flex-shrink: 0; display: inline-flex; align-items: center; justify-content: center; }
+  .krav.done .kbox { background: hsl(var(--t-success-fg)); color: hsl(0 0% 10%); }
+  .krav.done .kbox svg { width: 11px; height: 11px; }
+  .krav .ktext { color: hsl(var(--foreground)); }
+  .krav .kbadge { margin-left: auto; font-size: 10.5px; font-weight: 500; color: hsl(var(--muted-foreground)); }
+  .diff-row { display: flex; gap: 10px; font-size: 13px; padding: 9px 12px; border: 1px solid hsl(var(--border)); border-radius: 9px; background: hsl(var(--background)); margin-bottom: 7px; align-items: flex-start; }
+  .diff-tag { flex-shrink: 0; font-size: 10.5px; font-weight: 600; padding: 2px 7px; border-radius: 5px; }
+  .diff-tag.amend { background: hsl(var(--t-warning-bg)); color: hsl(var(--t-warning-fg)); }
+  .diff-tag.new { background: hsl(var(--t-success-bg)); color: hsl(var(--t-success-fg)); }
+  .diff-row code { font-family: 'SF Mono','Menlo',monospace; font-size: 12px; background: hsl(var(--muted)); padding: 1px 6px; border-radius: 4px; color: hsl(var(--foreground)); }
+  .underlag { border: 1px solid hsl(var(--border)); border-radius: 11px; overflow: hidden; background: hsl(var(--background)); }
+  .underlag-head { display: flex; align-items: center; gap: 10px; padding: 11px 14px; cursor: pointer; transition: background 150ms ease; user-select: none; }
+  .underlag-head:hover { background: hsl(var(--muted) / .4); }
+  .underlag-head .ul-t { font-size: 12.5px; font-weight: 600; color: hsl(var(--foreground)); display: flex; align-items: center; gap: 8px; }
+  .underlag-head .ul-m { margin-left: auto; font-size: 11.5px; color: hsl(var(--muted-foreground)); display: inline-flex; align-items: center; gap: 8px; }
+  .underlag-head .ul-chev { transition: transform 220ms ease; color: hsl(var(--muted-foreground)); }
+  .underlag-head .ul-chev svg { width: 14px; height: 14px; }
+  .underlag.open .ul-chev { transform: rotate(180deg); }
+  .underlag-body { display: none; padding: 16px 14px; border-top: 1px solid hsl(var(--border)); flex-direction: column; gap: 13px; }
+  .underlag.open .underlag-body { display: flex; }
+  .msg-user { align-self: flex-end; max-width: 86%; background: hsl(var(--foreground)); color: hsl(var(--background)); padding: 9px 13px; border-radius: 13px 13px 4px 13px; font-size: 13px; line-height: 1.5; }
+  .msg-ai { max-width: 100%; display: flex; gap: 10px; }
+  .msg-ai .av { flex-shrink: 0; width: 26px; height: 26px; border-radius: 7px; background: hsl(var(--muted)); color: hsl(var(--gold)); display: flex; align-items: center; justify-content: center; }
+  .msg-ai .av svg { width: 15px; height: 15px; }
+  .msg-ai .ct { min-width: 0; flex: 1; font-size: 13px; color: hsl(var(--foreground)); line-height: 1.6; }
+  .msg-ai .ct p { margin: 0 0 9px; } .msg-ai .ct p:last-child { margin: 0; }
+  .msg-ai .ct code { font-family: 'SF Mono','Menlo',monospace; font-size: 12px; background: hsl(var(--muted)); padding: 1px 5px; border-radius: 4px; }
+  .ul-foot { display: flex; align-items: center; gap: 8px; font-size: 11.5px; color: hsl(var(--muted-foreground)); padding-top: 2px; }
+  .ul-foot svg { width: 12px; height: 12px; }
+  .ul-foot .open-full { margin-left: auto; color: hsl(var(--t-info-fg)); font-weight: 500; cursor: pointer; display: inline-flex; align-items: center; gap: 4px; }
+  .d-actions { display: flex; gap: 8px; margin-top: 8px; flex-wrap: wrap; }
+  .btn { appearance: none; font: inherit; font-weight: 500; font-size: 13px; border: 1px solid hsl(var(--border)); background: transparent; color: hsl(var(--foreground)); padding: 8px 13px; border-radius: 8px; cursor: pointer; transition: all 150ms ease; display: inline-flex; align-items: center; gap: 7px; }
+  .btn:hover { background: hsl(var(--muted) / .5); }
+  .btn svg { width: 14px; height: 14px; }
+  .btn.solid { background: hsl(var(--foreground)); color: hsl(var(--background)); border-color: hsl(var(--foreground)); }
+  .btn.solid:hover { background: hsl(var(--foreground) / .9); }
+  .detail-empty { display: none; flex-direction: column; align-items: center; justify-content: center; height: 100%; text-align: center; gap: 10px; color: hsl(var(--muted-foreground)); padding: 40px; }
+  .state-3 .tl-body:not(.detail-open) .detail-empty { display: flex; }
+  .state-3 .tl-body:not(.detail-open) .detail-scroll { display: none; }
+  .detail-empty .ic { width: 52px; height: 52px; border-radius: 999px; background: hsl(var(--muted)); display: inline-flex; align-items: center; justify-content: center; }
+  .detail-empty .ic svg { width: 22px; height: 22px; }
+  .detail-empty .t { font-size: 14px; font-weight: 600; color: hsl(var(--foreground)); }
+  .detail-empty .h { font-size: 12.5px; max-width: 250px; }
+
+  /* chat mode */
+  .chat-body { flex: 1; min-height: 0; overflow-y: auto; padding: 20px 18px 14px; display: flex; flex-direction: column; gap: 16px; }
+  .chat-footer { padding: 14px 16px 16px; border-top: 1px solid hsl(var(--border)); flex-shrink: 0; }
+  .chat-input { border: 1px solid hsl(var(--border)); border-radius: 12px; background: hsl(var(--background)); padding: 10px 12px; display: flex; gap: 8px; align-items: flex-end; }
+  .chat-input:focus-within { border-color: hsl(var(--gold) / .4); }
+  .chat-input textarea { flex: 1; min-height: 22px; max-height: 100px; font: inherit; font-size: 14px; border: 0; background: transparent; resize: none; outline: none; padding: 4px 0; color: hsl(var(--foreground)); line-height: 1.5; }
+  .chat-input textarea::placeholder { color: hsl(var(--muted-foreground)); }
+  .send { appearance: none; border: 0; width: 30px; height: 30px; border-radius: 8px; background: hsl(var(--foreground)); color: hsl(var(--background)); cursor: pointer; display: inline-flex; align-items: center; justify-content: center; flex-shrink: 0; }
+  .send svg { width: 14px; height: 14px; }
+  .chat-hint { margin-top: 9px; font-size: 11.5px; color: hsl(var(--muted-foreground)); }
+
+  /* rail */
+  .rail-inner { display: flex; flex-direction: column; align-items: center; gap: 4px; padding: 12px 0; height: 100%; opacity: 0; transition: opacity 260ms ease 200ms; }
+  .state-2 .rail-inner { opacity: 1; }
+  .rail-icon { appearance: none; background: transparent; border: 0; width: 32px; height: 32px; border-radius: 8px; color: hsl(var(--muted-foreground)); cursor: pointer; display: inline-flex; align-items: center; justify-content: center; transition: all 150ms ease; }
+  .rail-icon:hover { background: hsl(var(--muted)); color: hsl(var(--foreground)); }
+  .rail-icon svg { width: 15px; height: 15px; }
+  .rail-icon .sdot { width: 9px; height: 9px; border-radius: 999px; background: hsl(215 15% 55%); }
+  .rail-sep { width: 20px; height: 1px; background: hsl(var(--border)); margin: 6px 0; }
+
+  /* callouts */
+  .callouts { max-width: min(94vw, 1240px); margin: 18px auto 0; display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+  .callout { padding: 13px 15px; border-radius: 10px; background: hsl(0 0% 11%); border: 1px solid hsl(var(--border)); color: hsl(0 0% 78%); font-size: 12px; line-height: 1.55; }
+  .callout strong { display: block; font-size: 11px; font-weight: 600; letter-spacing: .06em; text-transform: uppercase; color: hsl(var(--t-info-fg)); margin-bottom: 4px; }
+  .callout.warn strong { color: hsl(var(--t-warning-fg)); }
+  .callout.ok strong { color: hsl(var(--t-success-fg)); }
+
+  @media (max-width: 900px) { .scene { padding: 12px; } .modal { width: 100%; height: calc(100vh - 130px); } .callouts { grid-template-columns: 1fr; } }
+</style>
+</head>
+<body>
+
+<header class="proto-bar">
+  <div class="proto-brand"><span class="dot"></span><span class="font-safiro">Laglig</span> · Tidslinje i lagmodalen</div>
+  <div class="seg-group" id="state-toggle" role="tablist">
+    <button type="button" data-state="state-1" role="tab"><span class="k">1</span> Stängd</button>
+    <button type="button" data-state="state-2" class="active" role="tab"><span class="k">2</span> Öppen</button>
+    <button type="button" data-state="state-3" role="tab"><span class="k">3</span> Expanderad</button>
+  </div>
+  <span class="proto-label">Innehåll</span>
+  <div class="seg-group" id="content-toggle">
+    <button type="button" data-content="full" class="active">Fullständig</button>
+    <button type="button" data-content="sparse">Ny lag (gles)</button>
+  </div>
+  <div class="proto-spacer"></div>
+</header>
+
+<main class="scene state-2" id="scene">
+  <div class="modal" id="modal">
+
+    <div class="modal-header">
+      <div class="breadcrumb"><a href="#">Er laglista</a></div>
+      <div class="header-actions">
+        <button class="icon-btn" title="Lexa"><span class="lexa-mark"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4v13a3 3 0 0 0 3 3h7"/></svg></span></button>
+        <button class="icon-btn" title="Dela"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg></button>
+        <button class="icon-btn" title="Mer"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="5" cy="12" r="1.5"/><circle cx="12" cy="12" r="1.5"/><circle cx="19" cy="12" r="1.5"/></svg></button>
+        <button class="icon-btn" title="Stäng"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></button>
+      </div>
+    </div>
+
+    <div class="strip">
+      <div class="strip-inner">
+        <div class="strip-icon"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg></div>
+        <div>
+          <div class="strip-title">Aktiebolagslag (2005:551)</div>
+          <div class="strip-meta"><span class="badge neutral" style="padding:2px 7px;font-size:11px;"><span class="dot"></span>Ej påbörjad</span><span>·</span><span>1 kräver åtgärd · 8 i historiken</span></div>
+        </div>
+        <button class="strip-return" id="strip-collapse"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>Tillbaka till lagen</button>
+      </div>
+    </div>
+
+    <div class="modal-body">
+
+      <!-- LEFT CONTENT PANEL -->
+      <section class="content-panel">
+        <div class="content-inner">
+          <h2 class="law-title font-safiro">Aktiebolagslag (2005:551)</h2>
+          <div class="badge-row">
+            <span class="badge neutral"><span class="dot"></span>Ej påbörjad</span>
+            <span class="badge warning"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z"/><line x1="4" y1="22" x2="4" y2="15"/></svg>Medel</span>
+            <button class="icon-btn toggle-all" title="Expandera alla"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 15l5 5 5-5"/><path d="M7 9l5-5 5 5"/></svg></button>
+          </div>
+
+          <div class="group" data-group="efterlevnad">
+            <button class="group-label"><span class="gl-text font-safiro">Efterlevnad</span><span class="gl-line"></span><span class="gl-count">3</span><svg class="gl-chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></button>
+            <div class="group-content">
+              <div class="acc"><div class="acc-head"><span class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg></span>Hur påverkar detta oss?<span class="chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></span></div><div class="acc-body">Aktiebolagslagen reglerar bolagets organisation, styrelseansvar, bolagsstämma, kapitalskydd och utdelning.</div></div>
+              <div class="acc closed"><div class="acc-head"><span class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg></span>Hur efterlever vi kraven?<span class="chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></span></div><div class="acc-body">Ingen beskrivning ännu.</div></div>
+              <div class="acc closed"><div class="acc-head"><span class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="8" y="2" width="8" height="4" rx="1"/><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/><path d="M9 14l2 2 4-4"/></svg></span>Kravpunkter<span class="mc">0 / 4</span><span class="chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></span></div><div class="acc-body">Styrelsemöten · Bolagsstämma · Kapitalskydd · Revision</div></div>
+            </div>
+          </div>
+
+          <div class="group collapsed" data-group="referens">
+            <button class="group-label"><span class="gl-text font-safiro">Referens</span><span class="gl-line"></span><span class="gl-count">1</span><svg class="gl-chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></button>
+            <div class="group-content"><div class="acc closed"><div class="acc-head"><span class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg></span>Författningstext<span class="chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></span></div><div class="acc-body">Hela lagtexten visas här…</div></div></div>
+          </div>
+
+          <div class="group collapsed" data-group="underlag">
+            <button class="group-label"><span class="gl-text font-safiro">Uppgifter &amp; filer</span><span class="gl-line"></span><span class="gl-count">2</span><svg class="gl-chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></button>
+            <div class="group-content"><div class="acc closed"><div class="acc-head"><span class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="9" y1="6" x2="20" y2="6"/><line x1="9" y1="12" x2="20" y2="12"/><line x1="9" y1="18" x2="20" y2="18"/><polyline points="3 6 4 7 6 5"/></svg></span>Uppgifter<span class="chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></span></div><div class="acc-body">Inga länkade uppgifter.</div></div></div>
+          </div>
+
+          <div class="activity">
+            <h3>Kommentarer</h3>
+            <div class="comment-box"><span class="avatar-xs" style="background:hsl(214 45% 45%);">DU</span><span class="cb">Skriv en kommentar…</span></div>
+            <!-- Historik-fliken är borttagen: tidslinjen är den kanoniska historiken. -->
+            <div class="act-promo">
+              <span class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="2" x2="12" y2="22"/><circle cx="12" cy="6" r="2.5"/><circle cx="12" cy="13" r="2.5"/><circle cx="12" cy="20" r="2.5"/></svg></span>
+              <span class="txt"><b>Historiken bor i tidslinjen</b> — lagändringar, bedömningar, statusbyten och uppgifter, klickbara.</span>
+              <button class="btn" id="open-timeline-2">Öppna tidslinjen</button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- RIGHT PANEL -->
+      <section class="right-panel">
+        <div class="right-inner">
+          <div class="card">
+            <h4>Detaljer</h4>
+            <div class="field"><span class="k">Dokumentnummer</span><span class="v">SFS 2005:551</span></div>
+            <div class="field"><span class="k">Efterlevnad</span><span class="v"><span class="v-pill neutral"><span class="dot"></span>Ej påbörjad <svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></span></span></div>
+            <div class="field"><span class="k">Prioritet</span><span class="v"><span class="v-pill warning"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" style="width:12px;height:12px;"><path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z"/><line x1="4" y1="22" x2="4" y2="15"/></svg>Medel <svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></span></span></div>
+            <div class="field"><span class="k">Ansvarig</span><span class="v v-muted"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:14px;height:14px;"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>Ingen tilldelad</span></div>
+            <div class="field"><span class="k">Senaste ändring</span><span class="v" style="gap:6px;"><a class="link-v" href="#">SFS 2026:495 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg></a><span class="badge-ny">Ny</span></span></div>
+          </div>
+
+          <div class="card">
+            <h4>Snabblänkar</h4>
+            <div class="ql-list">
+              <button class="ql"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>Visa fullständig lag</button>
+              <button class="ql" id="open-timeline"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="2" x2="12" y2="22"/><circle cx="12" cy="6" r="2.5"/><circle cx="12" cy="13" r="2.5"/><circle cx="12" cy="20" r="2.5"/></svg>Visa tidslinje<span class="ql-count">9</span></button>
+              <button class="ql solid" id="open-lexa"><span class="lexa-mark sm"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4v13a3 3 0 0 0 3 3h7"/></svg></span>Fråga Lexa om lagen</button>
+            </div>
+          </div>
+
+          <div class="card">
+            <h4>Översikt</h4>
+            <div class="overview-line"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg>0 länkade filer och dokument</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- WORK PANEL -->
+      <section class="work-panel" id="work-panel">
+        <div class="work-inner">
+
+          <div class="work-header">
+            <div class="mode-seg" id="mode-seg">
+              <button data-mode="timeline" class="active"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="2" x2="12" y2="22"/><circle cx="12" cy="6" r="2.5"/><circle cx="12" cy="13" r="2.5"/><circle cx="12" cy="20" r="2.5"/></svg>Tidslinje</button>
+              <button data-mode="chat"><span class="lexa-mark sm"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4v13a3 3 0 0 0 3 3h7"/></svg></span>Fråga Lexa</button>
+            </div>
+            <div class="work-actions">
+              <button class="icon-btn" id="density-btn" title="Kompakt vy"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/><line x1="3" y1="14" x2="21" y2="14"/><line x1="3" y1="18" x2="21" y2="18"/></svg></button>
+              <button class="icon-btn" title="Filtrera"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg></button>
+              <div class="divider"></div>
+              <button class="icon-btn" id="expand-btn" title="Expandera"><svg id="expand-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><line x1="21" y1="3" x2="14" y2="10"/><line x1="3" y1="21" x2="10" y2="14"/></svg></button>
+              <button class="icon-btn" id="close-work" title="Stäng"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></button>
+            </div>
+          </div>
+
+          <!-- MODE: TIMELINE -->
+          <div class="mode-pane active" id="pane-timeline">
+            <div class="tl-filterbar" id="tl-filterbar">
+              <button class="tl-filter active" data-filter="all">Alla <span class="cnt">9</span></button>
+              <button class="tl-filter" data-filter="amendment">Lagändringar <span class="cnt">2</span></button>
+              <button class="tl-filter" data-filter="assessment">Bedömningar <span class="cnt">3</span></button>
+              <button class="tl-filter" data-filter="finding">Avvikelser <span class="cnt">1</span></button>
+              <button class="tl-filter" data-filter="status">Status <span class="cnt">2</span></button>
+              <button class="tl-filter" data-filter="task">Uppgifter <span class="cnt">1</span></button>
+            </div>
+
+            <div class="tl-body" id="tl-body">
+              <div class="tl-list" id="tl-list">
+
+                <!-- sparse-state hint (only when content = "Ny lag") -->
+                <div class="tl-sparse-hint">
+                  <span class="sh-t"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>Tidslinjen är ny</span>
+                  <span class="sh-h">Den fylls på automatiskt allt eftersom lagen ändras och ni gör bedömningar. Hittills finns bara startpunkten.</span>
+                </div>
+
+                <!-- (1) KRÄVER ÅTGÄRD — open items lifted above the chronicle -->
+                <div class="tl-action-strip" id="tl-action-strip">
+                  <div class="tl-action-head">Kräver åtgärd <span class="cnt">1</span></div>
+                  <div class="tl-node tl-actionable t-amendment" data-type="amendment" data-detail="d0">
+                    <div class="tl-top">
+                      <span class="tl-kind"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="9" y1="15" x2="15" y2="15"/></svg></span>
+                      <div class="tl-textcol"><span class="tl-eyebrow">Lagändring · ej bedömd</span><span class="tl-title">SFS 2026:495</span></div>
+                      <span class="tl-date">19 maj</span>
+                    </div>
+                    <div class="tl-sub">Ändr. 7 kap. 10 §. Påverkar er bolagsstämmorutin — bör bedömas.</div>
+                    <div class="tl-tags"><span class="micro"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>Upptäckt automatiskt</span><button class="tl-cta" id="assess-cta">Bedöm nu</button></div>
+                  </div>
+                </div>
+
+                <div class="tl-stream">
+                <div class="tl-month">April 2026</div>
+                <div class="tl-track">
+                  <div class="tl-node t-status" data-type="status" data-detail="d2">
+                    <div class="tl-top"><span class="tl-kind"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg></span><div class="tl-textcol"><span class="tl-eyebrow">Statusändring</span><span class="tl-title">Efterlevnad: Pågående → Uppfylld</span></div><span class="tl-date">18 apr</span></div>
+                    <div class="tl-tags"><span class="verdict delvis"><span class="vd"></span>Pågående</span><span class="micro"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><polyline points="9 18 15 12 9 6"/></svg></span><span class="verdict uppfylld"><span class="vd"></span>Uppfylld</span><span class="micro"><span class="avatar-xs">AL</span>Anna Lind</span></div>
+                  </div>
+                  <div class="tl-node t-assessment" data-type="assessment" data-detail="d1">
+                    <div class="tl-top"><span class="tl-kind"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg></span><div class="tl-textcol"><span class="tl-eyebrow">Bedömning signerad</span><span class="tl-title">2026 Q2 Lagefterlevnadskontroll</span></div><span class="tl-date">18 apr</span></div>
+                    <div class="tl-sub">Bedömd som uppfylld efter att kravpunkterna verifierats mot uppdaterad bolagsordning.</div>
+                    <div class="tl-tags"><span class="verdict uppfylld"><span class="vd"></span>Uppfylld</span><span class="micro"><span class="avatar-xs">AL</span>Anna Lind</span><span class="micro"><span class="lexa-mark sm gold" style="width:11px;height:11px;"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4v13a3 3 0 0 0 3 3h7"/></svg></span>Lexa-underlag</span></div>
+                  </div>
+                  <div class="tl-node t-task" data-type="task" data-detail="d3">
+                    <div class="tl-top"><span class="tl-kind"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="9" y1="6" x2="20" y2="6"/><line x1="9" y1="12" x2="20" y2="12"/><polyline points="3 6 4 7 6 5"/><polyline points="3 12 4 13 6 11"/></svg></span><div class="tl-textcol"><span class="tl-eyebrow">Uppgift slutförd</span><span class="tl-title">Uppdatera bolagsordningen</span></div><span class="tl-date">15 apr</span></div>
+                    <div class="tl-sub">Spårades till avvikelsen i december. Stängd av Erik Sund.</div>
+                  </div>
+                </div>
+
+                <div class="tl-month">Mars 2026</div>
+                <div class="tl-track">
+                  <div class="tl-node t-action" data-type="assessment" data-detail="d4">
+                    <div class="tl-top"><span class="tl-kind"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="8" y="2" width="8" height="4" rx="1"/><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/><path d="M9 14l2 2 4-4"/></svg></span><div class="tl-textcol"><span class="tl-eyebrow">Bedömning av ändring</span><span class="tl-title">SFS 2025:804</span></div><span class="tl-date">22 mar</span></div>
+                    <div class="tl-sub">Ändringen i 8 kap. bedömdes kräva åtgärd — bolagsordningen behövde uppdateras.</div>
+                    <div class="tl-tags"><span class="verdict delvis"><span class="vd"></span>Åtgärd krävs</span><span class="micro danger">Påverkan: Hög</span><span class="micro"><span class="avatar-xs" style="background:hsl(28 55% 42%);">ES</span>Erik Sund</span><span class="micro"><span class="lexa-mark sm gold" style="width:11px;height:11px;"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4v13a3 3 0 0 0 3 3h7"/></svg></span>Lexa-underlag</span></div>
+                  </div>
+                  <div class="tl-node t-amendment" data-type="amendment" data-detail="d5">
+                    <div class="tl-top"><span class="tl-kind"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="9" y1="15" x2="15" y2="15"/></svg></span><div class="tl-textcol"><span class="tl-eyebrow">Lagändring trädde i kraft</span><span class="tl-title">SFS 2025:804</span></div><span class="tl-date">15 mar</span></div>
+                    <div class="tl-sub">Ändr. 8 kap. 17 §; ny 8 kap. 4 a §. Skärpta krav på dokumentation av styrelsens beslut.</div>
+                    <div class="tl-tags"><span class="verdict info"><span class="vd"></span>Trädde i kraft</span><span class="micro">2 §-ändringar</span></div>
+                  </div>
+                </div>
+
+                <div class="tl-month">December 2025</div>
+                <div class="tl-track">
+                  <div class="tl-node t-finding" data-type="finding" data-detail="d6b">
+                    <div class="tl-top"><span class="tl-kind"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg></span><div class="tl-textcol"><span class="tl-eyebrow">Avvikelse registrerad</span><span class="tl-title">Revisionsrutin ej dokumenterad</span></div><span class="tl-date">3 dec</span></div>
+                    <div class="tl-tags"><span class="verdict ej"><span class="vd"></span>Mindre avvikelse</span><span class="micro">Stängd 14 jan 2026</span></div>
+                  </div>
+                  <div class="tl-node t-assessment-partial" data-type="assessment" data-detail="d6">
+                    <div class="tl-top"><span class="tl-kind"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg></span><div class="tl-textcol"><span class="tl-eyebrow">Bedömning signerad</span><span class="tl-title">2025 Q4 Lagefterlevnadskontroll</span></div><span class="tl-date">3 dec</span></div>
+                    <div class="tl-sub">Delvis uppfylld — revisionsrutinen var inte dokumenterad.</div>
+                    <div class="tl-tags"><span class="verdict delvis"><span class="vd"></span>Delvis uppfylld</span><span class="micro"><span class="avatar-xs">AL</span>Anna Lind</span></div>
+                  </div>
+                </div>
+
+                <div class="tl-month" data-keep>September 2025</div>
+                <div class="tl-track">
+                  <div class="tl-node t-status" data-type="status" data-detail="d8" data-keep>
+                    <div class="tl-top"><span class="tl-kind"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></span><div class="tl-textcol"><span class="tl-eyebrow">Onboarding</span><span class="tl-title">Tillagd i laglistan</span></div><span class="tl-date">14 sep</span></div>
+                    <div class="tl-sub">Lagen lades till vid onboarding. Ändringar före detta datum räknas som befintliga.</div>
+                  </div>
+                </div>
+                <div style="height:8px;"></div>
+                </div>
+              </div>
+
+              <!-- DETAIL -->
+              <div class="tl-detail" id="tl-detail">
+                <div class="detail-head">
+                  <button class="detail-back" id="detail-back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>Tidslinje</button>
+                  <span class="dh">Detalj</span>
+                </div>
+                <div class="detail-empty">
+                  <span class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="2" x2="12" y2="22"/><circle cx="12" cy="6" r="2.5"/><circle cx="12" cy="13" r="2.5"/><circle cx="12" cy="20" r="2.5"/></svg></span>
+                  <span class="t">Välj en händelse</span>
+                  <span class="h">Klicka på en punkt för att se vad som gjordes — bedömningen, kravpunkterna och samtalet som ledde fram till slutsatsen.</span>
+                </div>
+                <div class="detail-scroll" id="detail-scroll">
+
+                  <div class="detail-block active" data-block="d0">
+                    <div class="d-eyebrow"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>Lagändring · väntar på bedömning</div>
+                    <h2 class="d-title font-safiro">SFS 2026:495</h2>
+                    <div class="d-metarow"><span class="d-meta"><span class="verdict info"><span class="vd"></span>Ej bedömd</span></span><span class="d-meta">Trädde i kraft 19 maj 2026</span></div>
+                    <div class="d-section"><div class="d-label">Sammanfattning</div><div class="d-text">Lag om ändring i aktiebolagslagen. Justerar reglerna för kallelse till bolagsstämma i 7 kap. 10 §.</div></div>
+                    <div class="d-section"><div class="d-label">Berörda paragrafer</div><div class="diff-row"><span class="diff-tag amend">Ändr.</span><div><code>7 kap. 10 §</code> — ändrad tidsfrist för kallelse.</div></div></div>
+                    <div class="d-section"><div class="d-text" style="font-size:12.5px;color:hsl(var(--muted-foreground));display:flex;gap:8px;align-items:flex-start;"><svg viewBox="0 0 24 24" fill="none" stroke="hsl(var(--gold))" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:15px;height:15px;flex-shrink:0;margin-top:1px;"><path d="M7 4v13a3 3 0 0 0 3 3h7"/></svg>Bedömningen görs genom Lexa. När du avslutar samtalet sparas konversationen som underlag på bedömningen och dyker upp här i tidslinjen.</div></div>
+                    <div class="d-actions"><button class="btn solid" id="assess-via-lexa"><span class="lexa-mark sm" style="margin-right:-2px;"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4v13a3 3 0 0 0 3 3h7"/></svg></span>Bedöm påverkan med Lexa</button><button class="btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/></svg>Ändringsdokument</button></div>
+                  </div>
+
+                  <div class="detail-block" data-block="d1">
+                    <div class="d-eyebrow"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 11l3 3L22 4"/></svg>Bedömning · Lagefterlevnadskontroll</div>
+                    <h2 class="d-title font-safiro">2026 Q2 — efterlevnad bedömd som uppfylld</h2>
+                    <div class="d-metarow"><span class="d-meta"><span class="verdict uppfylld"><span class="vd"></span>Uppfylld</span></span><span class="d-meta"><span class="avatar-xs">AL</span>Signerad av Anna Lind</span><span class="d-meta">18 apr 2026, 14:32</span></div>
+                    <div class="d-section"><div class="d-label"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>Motivering</div><div class="d-quote">Samtliga fyra kravpunkter är verifierade. Bolagsordningen uppdaterades efter SFS 2025:804 och styrelsens dokumentationsrutin följer nu 8 kap. 4 a §. Revisionsrutinen är dokumenterad sedan december-avvikelsen stängdes.</div></div>
+                    <div class="d-section"><div class="d-label"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 11l3 3L22 4"/></svg>Kravpunkter vid signering (ögonblicksbild)</div>
+                      <div class="krav-list">
+                        <div class="krav done"><span class="kbox"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span class="ktext">Dokumenterade styrelsemöten, minst sex per år</span><span class="kbadge">Bevis ✓</span></div>
+                        <div class="krav done"><span class="kbox"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span class="ktext">Årsstämma inom 6 mån efter räkenskapsårets slut</span><span class="kbadge">Bevis ✓</span></div>
+                        <div class="krav done"><span class="kbox"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span class="ktext">Lägsta aktiekapital 25 000 kr</span></div>
+                        <div class="krav done"><span class="kbox"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span class="ktext">Dokumenterad revisionsrutin</span><span class="kbadge">Bevis ✓</span></div>
+                      </div>
+                    </div>
+                    <div class="d-section">
+                      <div class="d-label"><span class="lexa-mark sm gold"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4v13a3 3 0 0 0 3 3h7"/></svg></span>Underlag — samtalet som ledde fram till bedömningen</div>
+                      <div class="underlag" id="underlag-1">
+                        <div class="underlag-head"><span class="ul-t"><span class="lexa-mark sm gold"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4v13a3 3 0 0 0 3 3h7"/></svg></span>Lexa-konversation</span><span class="ul-m">3 meddelanden · 18 apr<span class="ul-chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></span></span></div>
+                        <div class="underlag-body">
+                          <div class="msg-user">Vi har uppdaterat bolagsordningen efter SFS 2025:804. Räcker det för att uppfylla 8 kap.?</div>
+                          <div class="msg-ai"><div class="av"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4v13a3 3 0 0 0 3 3h7"/></svg></div><div class="ct"><p>Uppdateringen täcker dokumentationskravet i <code>8 kap. 4 a §</code>. För att bedöma kapitlet som uppfyllt behöver ni också kunna visa att styrelseprotokollen lagras enligt den nya rutinen.</p><p>Av era länkade bevis ser jag sex protokoll för 2025 och en uppdaterad attestordning. Det motsvarar kraven.</p></div></div>
+                          <div class="msg-user">Bra. Då bedömer vi 8 kap. som uppfyllt.</div>
+                          <div class="ul-foot"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M9 12l2 2 4-4"/></svg>Fäst som underlag av Anna Lind<span class="open-full"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/></svg>Öppna hela samtalet</span></div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="d-actions"><button class="btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/></svg>Öppna kontrollen</button><button class="btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>Revisionsrapport</button></div>
+                  </div>
+
+                  <div class="detail-block" data-block="d2">
+                    <div class="d-eyebrow"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>Statusändring</div>
+                    <h2 class="d-title font-safiro">Efterlevnad: Pågående → Uppfylld</h2>
+                    <div class="d-metarow"><span class="d-meta"><span class="avatar-xs">AL</span>Anna Lind</span><span class="d-meta">18 apr 2026, 14:33</span></div>
+                    <div class="d-section"><div class="d-label">Orsak</div><div class="d-text">Statusen sattes automatiskt när bedömningen i 2026 Q2-kontrollen signerades.</div></div>
+                    <div class="d-actions"><button class="btn" data-goto="d1"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>Visa bedömningen</button></div>
+                  </div>
+
+                  <div class="detail-block" data-block="d3">
+                    <div class="d-eyebrow"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="9" y1="6" x2="20" y2="6"/><polyline points="3 6 4 7 6 5"/></svg>Uppgift</div>
+                    <h2 class="d-title font-safiro">Uppdatera bolagsordningen</h2>
+                    <div class="d-metarow"><span class="d-meta"><span class="verdict uppfylld"><span class="vd"></span>Slutförd</span></span><span class="d-meta"><span class="avatar-xs" style="background:hsl(28 55% 42%);">ES</span>Erik Sund</span><span class="d-meta">15 apr 2026</span></div>
+                    <div class="d-section"><div class="d-label">Sammanhang</div><div class="d-text">Skapades automatiskt från avvikelsen i bedömningen av SFS 2025:804. Bolagsordningen uppdaterades och godkändes på styrelsemötet.</div></div>
+                    <div class="d-actions"><button class="btn" data-goto="d4"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>Visa ursprungsbedömningen</button></div>
+                  </div>
+
+                  <div class="detail-block" data-block="d4">
+                    <div class="d-eyebrow"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="8" y="2" width="8" height="4" rx="1"/><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/></svg>Bedömning av lagändring</div>
+                    <h2 class="d-title font-safiro">SFS 2025:804 — åtgärd krävdes</h2>
+                    <div class="d-metarow"><span class="d-meta"><span class="verdict delvis"><span class="vd"></span>Åtgärd krävs</span></span><span class="d-meta"><span class="micro danger">Påverkan: Hög</span></span><span class="d-meta"><span class="avatar-xs" style="background:hsl(28 55% 42%);">ES</span>Erik Sund</span><span class="d-meta">22 mar 2026</span></div>
+                    <div class="d-section"><div class="d-label"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/></svg>Lexas analys</div><div class="d-text">Ändringen i 8 kap. 4 a § inför ett uttryckligt krav på att styrelsens beslutsunderlag dokumenteras och bevaras. Er nuvarande bolagsordning hänvisar till den gamla lydelsen och behöver uppdateras.</div></div>
+                    <div class="d-section"><div class="d-label">Bedömarens anteckning</div><div class="d-quote">Vi tar upp ändringen på styrelsemötet och uppdaterar bolagsordningen. Skapar en uppgift med Anna som ansvarig.</div></div>
+                    <div class="d-section">
+                      <div class="d-label"><span class="lexa-mark sm gold"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4v13a3 3 0 0 0 3 3h7"/></svg></span>Underlag — samtalet som ledde fram till bedömningen</div>
+                      <div class="underlag" id="underlag-4">
+                        <div class="underlag-head"><span class="ul-t"><span class="lexa-mark sm gold"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4v13a3 3 0 0 0 3 3h7"/></svg></span>Lexa-konversation</span><span class="ul-m">4 meddelanden · 22 mar<span class="ul-chev"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></span></span></div>
+                        <div class="underlag-body">
+                          <div class="msg-user">Vad innebär den nya ändringen i SFS 2025:804 för oss?</div>
+                          <div class="msg-ai"><div class="av"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4v13a3 3 0 0 0 3 3h7"/></svg></div><div class="ct"><p>Den största förändringen är <code>8 kap. 4 a §</code> som inför ett dokumentationskrav för styrelsens beslutsunderlag. Bolagsordningens skrivning om protokoll behöver ses över.</p></div></div>
+                          <div class="msg-user">Påverkar det någon av våra kravpunkter?</div>
+                          <div class="msg-ai"><div class="av"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4v13a3 3 0 0 0 3 3h7"/></svg></div><div class="ct"><p>Ja — kravpunkten "Dokumenterade styrelsemöten" berörs direkt. Jag rekommenderar att markera den som ej uppfylld tills bolagsordningen uppdaterats, och att skapa en åtgärd.</p></div></div>
+                          <div class="ul-foot"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M9 12l2 2 4-4"/></svg>Fäst som underlag av Erik Sund<span class="open-full"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/></svg>Öppna hela samtalet</span></div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="d-section"><div class="d-label">Resulterade i</div><div class="krav-list"><div class="krav done"><span class="kbox" style="background:hsl(var(--muted-foreground));"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span class="ktext">Uppgift: Uppdatera bolagsordningen</span><span class="kbadge">Slutförd 15 apr</span></div></div></div>
+                  </div>
+
+                  <div class="detail-block" data-block="d5">
+                    <div class="d-eyebrow"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>Lagändring</div>
+                    <h2 class="d-title font-safiro">SFS 2025:804</h2>
+                    <div class="d-metarow"><span class="d-meta"><span class="verdict info"><span class="vd"></span>Trädde i kraft 15 mar 2026</span></span><span class="d-meta">Publicerad 3 mar 2026</span></div>
+                    <div class="d-section"><div class="d-label">Sammanfattning</div><div class="d-text">Lag om ändring i aktiebolagslagen. Skärper kraven på dokumentation av styrelsens beslutsunderlag och inför en ny paragraf om bevarande. Bygger på prop. 2024/25:142.</div></div>
+                    <div class="d-section"><div class="d-label">Berörda paragrafer</div><div class="diff-row"><span class="diff-tag amend">Ändr.</span><div><code>8 kap. 17 §</code> — förtydligat ansvar för styrelsens protokoll.</div></div><div class="diff-row"><span class="diff-tag new">Ny</span><div><code>8 kap. 4 a §</code> — krav på dokumentation och bevarande av beslutsunderlag.</div></div></div>
+                    <div class="d-actions"><button class="btn solid" data-goto="d4"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="8" y="2" width="8" height="4" rx="1"/><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/></svg>Visa vår bedömning</button><button class="btn"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/></svg>Ändringsdokument (PDF)</button></div>
+                  </div>
+
+                  <div class="detail-block" data-block="d6">
+                    <div class="d-eyebrow"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 11l3 3L22 4"/></svg>Bedömning · Lagefterlevnadskontroll</div>
+                    <h2 class="d-title font-safiro">2025 Q4 — delvis uppfylld</h2>
+                    <div class="d-metarow"><span class="d-meta"><span class="verdict delvis"><span class="vd"></span>Delvis uppfylld</span></span><span class="d-meta"><span class="avatar-xs">AL</span>Anna Lind</span><span class="d-meta">3 dec 2025</span></div>
+                    <div class="d-section"><div class="d-label">Motivering</div><div class="d-quote">Tre av fyra kravpunkter uppfyllda. Revisionsrutinen var inte dokumenterad vid kontrolltillfället — registrerades som avvikelse.</div></div>
+                    <div class="d-actions"><button class="btn" data-goto="d6b"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/></svg>Visa avvikelsen</button></div>
+                  </div>
+
+                  <div class="detail-block" data-block="d6b">
+                    <div class="d-eyebrow"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/></svg>Avvikelse</div>
+                    <h2 class="d-title font-safiro">Revisionsrutin ej dokumenterad</h2>
+                    <div class="d-metarow"><span class="d-meta"><span class="verdict ej"><span class="vd"></span>Mindre</span></span><span class="d-meta">Öppnad 3 dec 2025 · Stängd 14 jan 2026</span></div>
+                    <div class="d-section"><div class="d-label">Beskrivning</div><div class="d-text">Vid 2025 Q4-kontrollen saknades dokumentation av revisionsrutinen enligt 9 kap. Avvikelsen stängdes efter att rutinen dokumenterats och bifogats som bevis.</div></div>
+                    <div class="d-actions"><button class="btn" data-goto="d6"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>Visa bedömningen</button></div>
+                  </div>
+
+                  <div class="detail-block" data-block="d8">
+                    <div class="d-eyebrow"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>Onboarding</div>
+                    <h2 class="d-title font-safiro">Tillagd i laglistan</h2>
+                    <div class="d-metarow"><span class="d-meta">14 sep 2025</span><span class="d-meta"><span class="avatar-xs">AL</span>Anna Lind</span></div>
+                    <div class="d-section"><div class="d-text">Aktiebolagslagen lades till i er laglista. Detta är tidslinjens startpunkt — lagändringar som trädde i kraft före detta datum betraktas som befintliga och kräver ingen bedömning.</div></div>
+                  </div>
+
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- MODE: FRÅGA LEXA -->
+          <div class="mode-pane" id="pane-chat">
+            <div class="chat-body">
+              <div class="msg-user">Vad gäller för vår bolagsstyrning enligt den här lagen?</div>
+              <div class="msg-ai"><div class="av"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4v13a3 3 0 0 0 3 3h7"/></svg></div><div class="ct"><p>Aktiebolagslagen (2005:551) reglerar styrelseansvar (<code>8 kap.</code>), bolagsstämma (<code>7 kap.</code>), kapitalskydd (<code>17 kap.</code>) och revision (<code>9 kap.</code>).</p><p>Vill ni att jag går djupare in på något område?</p></div></div>
+            </div>
+            <div class="chat-footer">
+              <div class="chat-input"><textarea rows="1" placeholder="Skriv din fråga..."></textarea><button class="send"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg></button></div>
+              <div class="chat-hint">Samma yta som tidslinjen — växla med reglaget ovan.</div>
+            </div>
+          </div>
+
+        </div>
+      </section>
+
+      <aside class="rail">
+        <div class="rail-inner">
+          <button class="rail-icon" title="Efterlevnad: Ej påbörjad"><span class="sdot"></span></button>
+          <button class="rail-icon" title="Prioritet: Medel"><svg viewBox="0 0 24 24" fill="none" stroke="hsl(var(--t-warning-fg))" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z"/><line x1="4" y1="22" x2="4" y2="15"/></svg></button>
+          <div class="rail-sep"></div>
+          <button class="rail-icon" title="Fullständig lag"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg></button>
+        </div>
+      </aside>
+
+    </div>
+  </div>
+</main>
+
+<div class="callouts">
+  <div class="callout warn"><strong>1 · Kräver åtgärd</strong>Öppna, obearbetade poster (t.ex. en ej bedömd lagändring) lyfts ur kronologin till en egen strip överst — historiken begraver inte det som behöver göras.</div>
+  <div class="callout"><strong>2 · En typ-signal</strong>Ikonbrickan bär typ, pillret bär utfall, och tidslinjens prick är en neutral trådmarkör. Prova "Kompakt vy" (ikonen i panelhuvudet) för tätare rader.</div>
+  <div class="callout ok"><strong>3 · Gles vy</strong>Växla "Innehåll → Ny lag" uppe till vänster för att se hur en nyss tillagd lag ser ut: bara startpunkten + en vänlig instruktion.</div>
+</div>
+<div style="height: 36px;"></div>
+
+<script>
+(() => {
+  const scene = document.getElementById('scene');
+  const stateBtns = document.querySelectorAll('#state-toggle button[data-state]');
+  const expandBtn = document.getElementById('expand-btn');
+  const expandIcon = document.getElementById('expand-icon');
+
+  const EXPAND_SVG = '<polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><line x1="21" y1="3" x2="14" y2="10"/><line x1="3" y1="21" x2="10" y2="14"/>';
+  const COLLAPSE_SVG = '<polyline points="4 14 10 14 10 20"/><polyline points="20 10 14 10 14 4"/><line x1="14" y1="10" x2="21" y2="3"/><line x1="3" y1="21" x2="10" y2="14"/>';
+
+  function setState(next) {
+    scene.classList.remove('state-1','state-2','state-3');
+    scene.classList.add(next);
+    stateBtns.forEach(b => b.classList.toggle('active', b.dataset.state === next));
+    expandIcon.innerHTML = next === 'state-3' ? COLLAPSE_SVG : EXPAND_SVG;
+    expandBtn.title = next === 'state-3' ? 'Kollapsa' : 'Expandera';
+  }
+  stateBtns.forEach(b => b.addEventListener('click', () => setState(b.dataset.state)));
+  expandBtn.addEventListener('click', () => {
+    const cur = [...scene.classList].find(c => c.startsWith('state-'));
+    setState(cur === 'state-3' ? 'state-2' : 'state-3');
+  });
+  document.getElementById('close-work').addEventListener('click', () => setState('state-1'));
+  document.getElementById('strip-collapse').addEventListener('click', () => setState('state-2'));
+
+  // content toggle (full / sparse)
+  document.querySelectorAll('#content-toggle button').forEach(b => b.addEventListener('click', () => {
+    document.querySelectorAll('#content-toggle button').forEach(x => x.classList.remove('active'));
+    b.classList.add('active');
+    scene.classList.toggle('sparse', b.dataset.content === 'sparse');
+  }));
+
+  // mode switch
+  const modeSeg = document.getElementById('mode-seg');
+  const panes = { timeline: document.getElementById('pane-timeline'), chat: document.getElementById('pane-chat') };
+  function setMode(mode) {
+    modeSeg.querySelectorAll('button').forEach(b => b.classList.toggle('active', b.dataset.mode === mode));
+    Object.entries(panes).forEach(([k, el]) => el.classList.toggle('active', k === mode));
+  }
+  modeSeg.querySelectorAll('button').forEach(b => b.addEventListener('click', () => setMode(b.dataset.mode)));
+  document.getElementById('open-timeline').addEventListener('click', () => { setMode('timeline'); setState('state-2'); });
+  document.getElementById('open-timeline-2').addEventListener('click', () => { setMode('timeline'); setState('state-2'); });
+  document.getElementById('open-lexa').addEventListener('click', () => { setMode('chat'); setState('state-2'); });
+
+  // density toggle
+  const list = document.getElementById('tl-list');
+  document.getElementById('density-btn').addEventListener('click', (e) => {
+    const on = list.classList.toggle('compact');
+    e.currentTarget.classList.toggle('on', on);
+    e.currentTarget.title = on ? 'Bekväm vy' : 'Kompakt vy';
+  });
+
+  // master/detail
+  const tlBody = document.getElementById('tl-body');
+  const nodes = document.querySelectorAll('.tl-node');
+  const blocks = document.querySelectorAll('.detail-block');
+  const detailScroll = document.getElementById('detail-scroll');
+  function showDetail(id) {
+    blocks.forEach(b => b.classList.toggle('active', b.dataset.block === id));
+    nodes.forEach(n => n.classList.toggle('active', n.dataset.detail === id));
+    tlBody.classList.add('detail-open');
+    if (detailScroll) detailScroll.scrollTop = 0;
+  }
+  nodes.forEach(n => n.addEventListener('click', (e) => { if (e.target.closest('.tl-cta')) return; showDetail(n.dataset.detail); }));
+  document.getElementById('detail-back').addEventListener('click', () => {
+    tlBody.classList.remove('detail-open');
+    nodes.forEach(n => n.classList.remove('active'));
+  });
+  document.querySelectorAll('[data-goto]').forEach(btn => btn.addEventListener('click', () => showDetail(btn.dataset.goto)));
+  document.getElementById('assess-cta').addEventListener('click', () => { showDetail('d0'); });
+  document.getElementById('assess-via-lexa')?.addEventListener('click', () => setMode('chat'));
+
+  // underlag collapsibles
+  document.querySelectorAll('.underlag-head').forEach(h => h.addEventListener('click', () => h.closest('.underlag').classList.toggle('open')));
+
+  // filters — apply to all nodes (incl. the action strip); hide empty sections
+  const actionStrip = document.getElementById('tl-action-strip');
+  document.querySelectorAll('.tl-filter').forEach(f => f.addEventListener('click', () => {
+    document.querySelectorAll('.tl-filter').forEach(x => x.classList.remove('active'));
+    f.classList.add('active');
+    const filt = f.dataset.filter;
+    nodes.forEach(n => { n.style.display = (filt === 'all' || n.dataset.type === filt) ? '' : 'none'; });
+    // hide the "Kräver åtgärd" strip if its node is filtered out
+    const stripVisible = [...actionStrip.querySelectorAll('.tl-node')].some(n => n.style.display !== 'none');
+    actionStrip.style.display = stripVisible ? '' : 'none';
+    // hide empty month groups
+    document.querySelectorAll('.tl-track').forEach(track => {
+      const any = [...track.querySelectorAll('.tl-node')].some(n => n.style.display !== 'none');
+      track.style.display = any ? '' : 'none';
+      const m = track.previousElementSibling;
+      if (m && m.classList.contains('tl-month')) m.style.display = any ? '' : 'none';
+    });
+  }));
+
+  // left panel
+  document.querySelectorAll('.content-panel .acc-head').forEach(h => h.addEventListener('click', () => h.closest('.acc').classList.toggle('closed')));
+  document.querySelectorAll('.group-label').forEach(l => l.addEventListener('click', () => l.closest('.group').classList.toggle('collapsed')));
+  document.querySelector('.toggle-all')?.addEventListener('click', () => {
+    document.querySelectorAll('.content-panel .group').forEach(g => g.classList.remove('collapsed'));
+    document.querySelectorAll('.content-panel .acc').forEach(a => a.classList.remove('closed'));
+  });
+
+  document.querySelectorAll('.chat-input textarea').forEach(ta => ta.addEventListener('input', () => { ta.style.height = 'auto'; ta.style.height = Math.min(ta.scrollHeight, 100) + 'px'; }));
+  document.getElementById('underlag-1')?.classList.add('open');
+})();
+</script>
+
+</body>
+</html>

--- a/_prototypes/legal-modal-left-panel-redesign.html
+++ b/_prototypes/legal-modal-left-panel-redesign.html
@@ -184,6 +184,36 @@
       .group-label::after { content: ""; flex: 1; height: 1px; background: var(--border-soft); }
       .group-label:first-of-type { margin-top: 4px; }
 
+      /* Collapsible group (Variant A2) — group header is itself a <details> */
+      .cgroup { margin-top: 18px; }
+      .cgroup:first-of-type { margin-top: 4px; }
+      .cgroup > summary {
+        list-style: none; cursor: pointer;
+        display: flex; align-items: center; gap: 10px; padding: 6px 2px;
+      }
+      .cgroup > summary::-webkit-details-marker { display: none; }
+      .cgroup-label {
+        font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.09em;
+        color: var(--accent-dim);
+      }
+      .cgroup > summary:hover .cgroup-label { color: var(--accent); }
+      .cgroup-rule { flex: 1; height: 1px; background: var(--border-soft); }
+      .cgroup-count {
+        min-width: 18px; height: 18px; padding: 0 6px; border-radius: 6px;
+        background: var(--neutral-bg); color: var(--fg-dim);
+        font-size: 11px; font-weight: 600;
+        display: inline-flex; align-items: center; justify-content: center;
+      }
+      .cgroup-chev { width: 15px; height: 15px; color: var(--fg-dim); transition: transform .18s; }
+      .cgroup[open] > summary .cgroup-chev { transform: rotate(180deg); }
+      .cgroup-items { padding-top: 8px; }
+      .cgroup:not([open]) > summary { opacity: 0.72; }
+
+      /* Typografi-jämförelse: statiska grupprader + Safiro på etiketten
+         (behåller versal-spärrningen, byter bara family + vikt) */
+      .tg-grouprow { display: flex; align-items: center; gap: 10px; padding: 7px 2px; }
+      .cgroup-label.is-safiro { font-family: 'Safiro', system-ui, sans-serif; font-weight: 500; }
+
       /* rich collapsed preview line */
       .preview-line { color: var(--fg-dim); font-size: 12.5px; max-width: 30ch; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 
@@ -274,8 +304,51 @@
         <span><i class="swatch" style="background:var(--accent)"></i> brand-accent</span>
       </div>
 
-      <!-- ════════════════ CURRENT ════════════════ -->
+      <!-- ════════════════ TYPOGRAFI — Safiro på titeln ════════════════ -->
       <div class="variant-head first">
+        <span class="eyebrow">Typografi</span>
+        <h2 class="variant-title">Titeln i Safiro? <span class="variant-tag rec">brand-moment</span></h2>
+        <p class="variant-desc">
+          Modalen är 100&nbsp;% Google Sans Flex idag. Här jämförs både lagtiteln <em>och</em>
+          grupprubrikerna i Safiro Medium (500) mot nuläget. Titeln blir elegant medium istället
+          för fet. Safiro på de versala smårubrikerna är subtilt (versal-spärrningen behålls, bara
+          family + vikt byts) — döm själv om det känns mer brand eller bara stökigare.
+        </p>
+
+        <div style="display:grid; gap:14px; margin-top:16px;">
+          <!-- Nuvarande -->
+          <div>
+            <div class="eyebrow" style="margin-bottom:8px;">Nuvarande · Google Sans Flex</div>
+            <div class="frame"><div class="panel-pad" style="padding:20px 24px;">
+              <h3 class="law-title" style="margin-bottom:12px;">Aktiebolagslag (2005:551)</h3>
+              <div class="badges" style="margin-bottom:14px;">
+                <span class="pill pill-status"><i class="dot"></i> Ej påbörjad</span>
+                <span class="pill pill-priority"><i data-lucide="flag" class="ic"></i> Medel</span>
+              </div>
+              <div class="tg-grouprow"><span class="cgroup-label">Efterlevnad</span><span class="cgroup-rule"></span><span class="cgroup-count">3</span><i data-lucide="chevron-down" class="cgroup-chev"></i></div>
+              <div class="tg-grouprow"><span class="cgroup-label">Referens</span><span class="cgroup-rule"></span><span class="cgroup-count">1</span><i data-lucide="chevron-down" class="cgroup-chev"></i></div>
+              <div class="tg-grouprow"><span class="cgroup-label">Uppgifter &amp; filer</span><span class="cgroup-rule"></span><span class="cgroup-count">2</span><i data-lucide="chevron-down" class="cgroup-chev"></i></div>
+            </div></div>
+          </div>
+          <!-- Safiro -->
+          <div>
+            <div class="eyebrow" style="margin-bottom:8px; color:var(--accent);">Förslag · Safiro Medium (titel + grupprubriker)</div>
+            <div class="frame"><div class="panel-pad" style="padding:20px 24px;">
+              <h3 class="law-title font-safiro" style="margin-bottom:12px; font-weight:500;">Aktiebolagslag (2005:551)</h3>
+              <div class="badges" style="margin-bottom:14px;">
+                <span class="pill pill-status"><i class="dot"></i> Ej påbörjad</span>
+                <span class="pill pill-priority"><i data-lucide="flag" class="ic"></i> Medel</span>
+              </div>
+              <div class="tg-grouprow"><span class="cgroup-label is-safiro">Efterlevnad</span><span class="cgroup-rule"></span><span class="cgroup-count">3</span><i data-lucide="chevron-down" class="cgroup-chev"></i></div>
+              <div class="tg-grouprow"><span class="cgroup-label is-safiro">Referens</span><span class="cgroup-rule"></span><span class="cgroup-count">1</span><i data-lucide="chevron-down" class="cgroup-chev"></i></div>
+              <div class="tg-grouprow"><span class="cgroup-label is-safiro">Uppgifter &amp; filer</span><span class="cgroup-rule"></span><span class="cgroup-count">2</span><i data-lucide="chevron-down" class="cgroup-chev"></i></div>
+            </div></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ════════════════ CURRENT ════════════════ -->
+      <div class="variant-head">
         <span class="eyebrow">Nuläge</span>
         <h2 class="variant-title">Sex dragspel + aktivitet</h2>
         <p class="variant-desc">
@@ -423,6 +496,134 @@
             </summary>
             <div class="body">
               <div class="obj-row"><i data-lucide="file-text"></i><span class="name">Bolagsordning_2024.pdf</span><span class="sub">PDF · 240 kB</span></div>
+            </div>
+          </details>
+
+          <div class="activity">
+            <p class="activity-h">Aktivitet</p>
+            <div class="act-tabs"><span class="on">Alla</span><span>Kommentarer</span><span>Historik</span></div>
+            <div class="act-empty"><div><i data-lucide="history"></i></div>Ingen aktivitet ännu</div>
+          </div>
+        </div>
+      </div>
+
+      <hr class="divider" />
+
+      <!-- ════════════════ VARIANT A2 (collapsible groups) ════════════════ -->
+      <div class="variant-head">
+        <span class="eyebrow">Riktning A2</span>
+        <h2 class="variant-title">A, men med hopfällbara grupper</h2>
+        <p class="variant-desc">
+          Som A — fast varje grupprubrik är klickbar och fäller ihop hela gruppen. Siffran vid
+          rubriken visar hur många rader som göms. Här är <b>Referens</b> ihopfällt (lagtexten
+          undanstoppad efter läsning). Notera de <em>två</em> nivåerna av chevroner.
+        </p>
+        <ul class="wins">
+          <li><i data-lucide="check"></i> Fäll undan ett helt område</li>
+          <li><i data-lucide="check"></i> Antal visar dolda rader</li>
+        </ul>
+        <div class="note">
+          <b>Avvägning:</b> nu finns två nivåer av öppna/stäng — grupp <em>och</em> rad. En dold
+          rad kan vara dold av två skäl, och det tillkommer state (fokus-scroll måste auto-öppna
+          en hopfälld grupp; "expandera alla" får ny innebörd). Värt det bara om "fokusera på ett
+          område" är ett verkligt behov — annars gör flikar (Riktning B nedan) det renare.
+        </div>
+      </div>
+
+      <div class="frame">
+        <div class="frame-bar">
+          <span class="crumb">Er laglista</span><i data-lucide="chevron-right"></i><span class="crumb"><b>SFS 2005:551</b></span>
+          <span class="spacer"></span><i data-lucide="share-2"></i><i data-lucide="more-horizontal"></i><i data-lucide="x"></i>
+        </div>
+        <div class="panel-pad">
+          <h3 class="law-title">Aktiebolagslag (2005:551)</h3>
+          <div class="badges">
+            <span class="pill pill-status"><i class="dot"></i> Ej påbörjad</span>
+            <span class="pill pill-priority"><i data-lucide="flag" class="ic"></i> Medel</span>
+            <button class="toggle-all"><i data-lucide="chevrons-up-down"></i></button>
+          </div>
+
+          <!-- Group: Efterlevnad (open) -->
+          <details class="cgroup" open>
+            <summary>
+              <span class="cgroup-label">Efterlevnad</span>
+              <span class="cgroup-rule"></span>
+              <span class="cgroup-count">3</span>
+              <i data-lucide="chevron-down" class="cgroup-chev"></i>
+            </summary>
+            <div class="cgroup-items">
+              <details class="acc">
+                <summary>
+                  <span class="ttl"><i data-lucide="circle-help" class="lead"></i> Hur påverkar detta oss?</span>
+                  <span class="meta"><span class="preview-line">Vi är ett aktiebolag och omfa…</span><i data-lucide="chevron-down" class="chev"></i></span>
+                </summary>
+                <div class="body"><p>Vi är ett aktiebolag och omfattas av reglerna om bolagsstyrning, styrelsens ansvar och årsredovisning.</p></div>
+              </details>
+              <details class="acc">
+                <summary>
+                  <span class="ttl"><i data-lucide="file-text" class="lead"></i> Hur efterlever vi kraven?</span>
+                  <span class="meta"><span class="empty-tag">ej ifylld</span><i data-lucide="chevron-down" class="chev"></i></span>
+                </summary>
+                <div class="body"><p class="empty-tag">Beskriv hur ni efterlever lagen.</p></div>
+              </details>
+              <details class="acc">
+                <summary>
+                  <span class="ttl"><i data-lucide="clipboard-check" class="lead"></i> Kravpunkter</span>
+                  <span class="meta"><span class="prog"><span class="track"><span class="fill" style="width:33%"></span></span><span class="lbl">1/3</span></span><i data-lucide="chevron-down" class="chev"></i></span>
+                </summary>
+                <div class="body" style="padding-right:8px">
+                  <div class="krav-row done"><span class="krav-box done"><i data-lucide="check"></i></span><span class="krav-txt">Registrerad bolagsordning hos Bolagsverket</span></div>
+                  <div class="krav-row"><span class="krav-box"></span><span class="krav-txt">Styrelseprotokoll förs vid varje sammanträde</span></div>
+                  <div class="krav-row"><span class="krav-box"></span><span class="krav-txt">Årsredovisning upprättas enligt ÅRL och ABL</span></div>
+                </div>
+              </details>
+            </div>
+          </details>
+
+          <!-- Group: Referens (collapsed — items hidden) -->
+          <details class="cgroup">
+            <summary>
+              <span class="cgroup-label">Referens</span>
+              <span class="cgroup-rule"></span>
+              <span class="cgroup-count">1</span>
+              <i data-lucide="chevron-down" class="cgroup-chev"></i>
+            </summary>
+            <div class="cgroup-items">
+              <details class="acc">
+                <summary>
+                  <span class="ttl"><i data-lucide="scale" class="lead"></i> Författningstext</span>
+                  <span class="meta"><span style="color:var(--fg-dim)">SFS 2005:551</span><i data-lucide="arrow-up-right" class="chev"></i></span>
+                </summary>
+                <div class="body"><p>Öppnas i fokuserad läsvy. <span style="color:var(--accent);cursor:pointer">Visa fullständig lag →</span></p></div>
+              </details>
+            </div>
+          </details>
+
+          <!-- Group: Underlag (open) -->
+          <details class="cgroup" open>
+            <summary>
+              <span class="cgroup-label">Underlag</span>
+              <span class="cgroup-rule"></span>
+              <span class="cgroup-count">2</span>
+              <i data-lucide="chevron-down" class="cgroup-chev"></i>
+            </summary>
+            <div class="cgroup-items">
+              <details class="acc">
+                <summary>
+                  <span class="ttl"><i data-lucide="list-checks" class="lead"></i> Uppgifter</span>
+                  <span class="meta"><span class="empty-tag">inga än</span><i data-lucide="chevron-down" class="chev"></i></span>
+                </summary>
+                <div class="body"><p class="empty-tag">Inga uppgifter kopplade.</p></div>
+              </details>
+              <details class="acc">
+                <summary>
+                  <span class="ttl"><i data-lucide="paperclip" class="lead"></i> Länkade filer &amp; dokument</span>
+                  <span class="meta"><span class="preview-line">Bolagsordning_2024.pdf</span><span class="count-chip">1</span><i data-lucide="chevron-down" class="chev"></i></span>
+                </summary>
+                <div class="body">
+                  <div class="obj-row"><i data-lucide="file-text"></i><span class="name">Bolagsordning_2024.pdf</span><span class="sub">PDF · 240 kB</span></div>
+                </div>
+              </details>
             </div>
           </details>
 

--- a/_prototypes/legal-modal-left-panel-redesign.html
+++ b/_prototypes/legal-modal-left-panel-redesign.html
@@ -1,0 +1,626 @@
+<!doctype html>
+<html lang="sv">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Legal modal — left-panel redesign (prototype)</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
+    <style>
+      @font-face {
+        font-family: 'Safiro';
+        src:
+          url('../public/fonts/safiro-medium-webfont.woff2') format('woff2'),
+          url('../public/fonts/safiro-medium-webfont.woff') format('woff');
+        font-weight: 500;
+        font-style: normal;
+        font-display: swap;
+      }
+      @font-face {
+        font-family: 'Google Sans Flex';
+        src: url('../public/fonts/GoogleSansFlex.ttf') format('truetype');
+        font-weight: 100 900;
+        font-style: normal;
+        font-display: swap;
+      }
+
+      :root {
+        /* Dark tokens — matched to the real app screenshot (neutral-warm dark) */
+        --bg: #0a0a09;          /* page backdrop */
+        --modal: #100f0e;       /* modal surface */
+        --panel: #121110;       /* left panel base */
+        --card: #1a1917;        /* accordion row / card surface */
+        --card-hi: #201f1c;     /* hovered / active surface */
+        --border: #2b2a26;      /* visible border */
+        --border-soft: #232220; /* hairline border */
+        --fg: #ededea;          /* primary text */
+        --fg-muted: #a39f97;    /* secondary text */
+        --fg-dim: #6e6a62;      /* tertiary / empty-state text */
+        --accent: #d6bd97;      /* warm sand brand accent */
+        --accent-dim: #8a7a5e;
+        --emerald: #34d399;
+        --emerald-track: #2a3a30;
+        --amber-bg: rgba(245, 158, 11, 0.14);
+        --amber-fg: #f0c469;
+        --neutral-bg: #26251f;
+        --neutral-fg: #b8b4ab;
+        --neutral-dot: #7c8896;
+        --blue-bg: rgba(59, 130, 246, 0.12);
+        --blue-border: rgba(59, 130, 246, 0.32);
+        --blue-fg: #b9cdf2;
+      }
+
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        font-family: 'Google Sans Flex', ui-sans-serif, system-ui, -apple-system, sans-serif;
+        font-size: 14px;
+        line-height: 1.55;
+        background:
+          radial-gradient(1200px 700px at 50% -10%, #15140f 0%, transparent 60%),
+          var(--bg);
+        color: var(--fg);
+        -webkit-font-smoothing: antialiased;
+        padding: 56px 24px 120px;
+      }
+      .font-safiro { font-family: 'Safiro', system-ui, sans-serif; font-weight: 500; letter-spacing: -0.01em; }
+
+      .wrap { max-width: 760px; margin: 0 auto; }
+
+      /* ── Page intro / section scaffolding ─────────────────────── */
+      .page-title { font-size: 26px; letter-spacing: -0.02em; margin: 0 0 6px; }
+      .page-sub { color: var(--fg-muted); font-size: 15px; margin: 0 0 8px; max-width: 64ch; }
+      .eyebrow {
+        font-size: 11px; font-weight: 600; text-transform: uppercase;
+        letter-spacing: 0.1em; color: var(--accent-dim);
+      }
+      .variant-head { margin: 72px 0 18px; }
+      .variant-head.first { margin-top: 40px; }
+      .variant-title { font-size: 20px; letter-spacing: -0.01em; margin: 6px 0 6px; display: flex; align-items: center; gap: 10px; }
+      .variant-tag {
+        font-size: 11px; font-weight: 600; padding: 3px 9px; border-radius: 999px;
+        background: var(--card); border: 1px solid var(--border); color: var(--fg-muted);
+      }
+      .variant-tag.rec { background: rgba(214,189,151,0.14); border-color: rgba(214,189,151,0.4); color: var(--accent); }
+      .variant-desc { color: var(--fg-muted); font-size: 14px; max-width: 66ch; margin: 0; }
+      .wins { list-style: none; padding: 0; margin: 12px 0 0; display: flex; flex-wrap: wrap; gap: 8px; }
+      .wins li {
+        font-size: 12px; color: var(--fg-muted);
+        background: var(--card); border: 1px solid var(--border-soft);
+        border-radius: 8px; padding: 5px 10px; display: inline-flex; align-items: center; gap: 6px;
+      }
+      .wins li svg { width: 13px; height: 13px; color: var(--emerald); }
+
+      /* ── Modal-left-panel frame ───────────────────────────────── */
+      .frame {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 16px;
+        box-shadow: 0 24px 60px -20px rgba(0,0,0,0.6);
+        overflow: hidden;
+      }
+      .frame-bar {
+        display: flex; align-items: center; gap: 8px;
+        padding: 10px 16px; border-bottom: 1px solid var(--border-soft);
+        font-size: 12.5px; color: var(--fg-muted); background: var(--modal);
+      }
+      .frame-bar .crumb { color: var(--fg-muted); }
+      .frame-bar .crumb b { color: var(--fg); font-weight: 500; }
+      .frame-bar .spacer { flex: 1; }
+      .frame-bar svg { width: 14px; height: 14px; }
+      .panel-pad { padding: 22px 24px 26px; }
+
+      /* Header (title + badges) shared by all variants */
+      .law-title { font-size: 21px; font-weight: 600; letter-spacing: -0.01em; margin: 0 0 12px; line-height: 1.25; }
+      .badges { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-bottom: 18px; }
+      .pill {
+        display: inline-flex; align-items: center; gap: 7px;
+        font-size: 12.5px; font-weight: 500; padding: 4px 11px; border-radius: 999px;
+      }
+      .pill .dot { width: 8px; height: 8px; border-radius: 50%; }
+      .pill .ic { width: 13px; height: 13px; }
+      .pill-status { background: var(--neutral-bg); color: var(--neutral-fg); }
+      .pill-status .dot { background: var(--neutral-dot); }
+      .pill-priority { background: var(--amber-bg); color: var(--amber-fg); }
+      .toggle-all {
+        margin-left: auto; width: 28px; height: 28px; border-radius: 7px;
+        display: inline-flex; align-items: center; justify-content: center;
+        color: var(--fg-dim); border: 1px solid transparent; cursor: pointer; background: none;
+      }
+      .toggle-all:hover { color: var(--fg); background: var(--card); }
+      .toggle-all svg { width: 16px; height: 16px; }
+
+      /* ── Accordion primitives (native <details>) ──────────────── */
+      .acc { border: 1px solid var(--border-soft); border-radius: 11px; background: var(--card); overflow: hidden; }
+      .acc + .acc { margin-top: 8px; }
+      .acc > summary {
+        list-style: none; cursor: pointer; padding: 14px 15px;
+        display: flex; align-items: center; gap: 11px;
+      }
+      .acc > summary::-webkit-details-marker { display: none; }
+      .acc > summary:hover { background: var(--card-hi); }
+      .acc .ttl { display: flex; align-items: center; gap: 11px; font-weight: 500; font-size: 14.5px; color: var(--fg); }
+      .acc .ttl .lead { width: 17px; height: 17px; color: var(--fg-muted); }
+      .acc .meta { margin-left: auto; display: flex; align-items: center; gap: 12px; color: var(--fg-muted); font-size: 12.5px; }
+      .acc .chev { width: 17px; height: 17px; color: var(--fg-dim); transition: transform .18s ease; }
+      .acc[open] .chev { transform: rotate(180deg); }
+      .acc .body { padding: 2px 16px 18px 43px; color: var(--fg-muted); font-size: 13.5px; }
+      .acc .body p { margin: 0 0 10px; }
+
+      .empty-tag { color: var(--fg-dim); font-style: italic; }
+      .count-chip {
+        min-width: 20px; height: 20px; padding: 0 6px; border-radius: 6px;
+        background: var(--neutral-bg); color: var(--neutral-fg); font-size: 11.5px; font-weight: 600;
+        display: inline-flex; align-items: center; justify-content: center;
+      }
+
+      /* progress bar */
+      .prog { display: inline-flex; align-items: center; gap: 8px; }
+      .prog .track { width: 46px; height: 6px; border-radius: 999px; background: var(--emerald-track); overflow: hidden; }
+      .prog .fill { height: 100%; background: var(--emerald); border-radius: 999px; }
+      .prog .lbl { color: var(--fg-muted); font-size: 12px; }
+
+      /* krav checklist rows */
+      .krav-row { display: flex; align-items: flex-start; gap: 10px; padding: 7px 0; border-top: 1px solid var(--border-soft); }
+      .krav-row:first-child { border-top: none; }
+      .krav-box { width: 17px; height: 17px; border-radius: 5px; border: 1.5px solid var(--fg-dim); flex-shrink: 0; margin-top: 1px; display: inline-flex; align-items: center; justify-content: center; }
+      .krav-box.done { background: var(--emerald); border-color: var(--emerald); }
+      .krav-box.done svg { width: 12px; height: 12px; color: #0a0a09; }
+      .krav-txt { color: var(--fg); font-size: 13.5px; }
+      .krav-row.done .krav-txt { color: var(--fg-muted); }
+
+      /* file / task chips inside bodies */
+      .obj-row { display: flex; align-items: center; gap: 10px; padding: 9px 11px; border: 1px solid var(--border-soft); border-radius: 9px; background: var(--modal); }
+      .obj-row svg { width: 15px; height: 15px; color: var(--fg-muted); }
+      .obj-row .name { color: var(--fg); font-size: 13px; }
+      .obj-row .sub { color: var(--fg-dim); font-size: 11.5px; margin-left: auto; }
+
+      /* group label (Variant A) */
+      .group-label {
+        display: flex; align-items: center; gap: 10px;
+        font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.09em;
+        color: var(--accent-dim); margin: 20px 2px 9px;
+      }
+      .group-label::after { content: ""; flex: 1; height: 1px; background: var(--border-soft); }
+      .group-label:first-of-type { margin-top: 4px; }
+
+      /* rich collapsed preview line */
+      .preview-line { color: var(--fg-dim); font-size: 12.5px; max-width: 30ch; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+      /* ── Tabs (Variant B) ─────────────────────────────────────── */
+      .tabbar { display: flex; gap: 2px; padding: 4px; background: var(--card); border: 1px solid var(--border-soft); border-radius: 11px; margin-bottom: 18px; }
+      .tab {
+        flex: 1; display: inline-flex; align-items: center; justify-content: center; gap: 7px;
+        padding: 8px 10px; border-radius: 8px; font-size: 13.5px; font-weight: 500;
+        color: var(--fg-muted); cursor: pointer; border: none; background: none; transition: all .15s;
+      }
+      .tab svg { width: 15px; height: 15px; }
+      .tab:hover { color: var(--fg); }
+      .tab.active { background: var(--modal); color: var(--fg); box-shadow: 0 1px 0 rgba(0,0,0,0.4); }
+      .tab .badge { min-width: 18px; height: 18px; padding: 0 5px; border-radius: 5px; background: var(--neutral-bg); color: var(--neutral-fg); font-size: 11px; font-weight: 600; display: inline-flex; align-items: center; justify-content: center; }
+      .tab.active .badge { background: rgba(214,189,151,0.16); color: var(--accent); }
+      .tabpane { display: none; }
+      .tabpane.active { display: block; animation: fade .2s ease; }
+      @keyframes fade { from { opacity: 0; transform: translateY(3px); } to { opacity: 1; transform: none; } }
+
+      .field-label { font-size: 12.5px; font-weight: 600; color: var(--fg); margin: 18px 0 7px; display: flex; align-items: center; gap: 8px; }
+      .field-label:first-child { margin-top: 0; }
+      .field-label .lead { width: 15px; height: 15px; color: var(--fg-muted); }
+      .field-box { background: var(--card); border: 1px solid var(--border-soft); border-radius: 10px; padding: 12px 14px; color: var(--fg-muted); font-size: 13.5px; }
+      .field-box.empty { color: var(--fg-dim); font-style: italic; border-style: dashed; }
+      .lagtext-reader { background: var(--card); border: 1px solid var(--border-soft); border-radius: 10px; padding: 16px 18px; color: var(--fg-muted); font-size: 13.5px; line-height: 1.6; }
+      .lagtext-reader h4 { color: var(--fg); font-size: 13px; margin: 0 0 4px; font-weight: 600; }
+      .lagtext-reader .para { padding: 10px 0; border-bottom: 1px solid var(--border-soft); }
+      .lagtext-reader .para:last-child { border-bottom: none; }
+
+      /* ── Stepper (Variant C) ──────────────────────────────────── */
+      .step { position: relative; padding-left: 40px; padding-bottom: 8px; }
+      .step::before { /* connector line */
+        content: ""; position: absolute; left: 14px; top: 30px; bottom: -8px; width: 2px; background: var(--border-soft);
+      }
+      .step:last-child::before { display: none; }
+      .step-node {
+        position: absolute; left: 0; top: 2px; width: 29px; height: 29px; border-radius: 50%;
+        display: inline-flex; align-items: center; justify-content: center;
+        font-size: 13px; font-weight: 600; background: var(--card); border: 1.5px solid var(--border); color: var(--fg-muted); z-index: 1;
+      }
+      .step-node.done { background: var(--emerald); border-color: var(--emerald); color: #0a0a09; }
+      .step-node.active { border-color: var(--accent); color: var(--accent); box-shadow: 0 0 0 4px rgba(214,189,151,0.1); }
+      .step-node svg { width: 15px; height: 15px; }
+      .step details { border-radius: 11px; }
+      .step summary { list-style: none; cursor: pointer; display: flex; align-items: center; gap: 10px; padding: 5px 0; }
+      .step summary::-webkit-details-marker { display: none; }
+      .step .s-ttl { font-weight: 600; font-size: 15px; color: var(--fg); }
+      .step .s-state { margin-left: auto; display: inline-flex; align-items: center; gap: 9px; font-size: 12.5px; }
+      .state-done { color: var(--emerald); }
+      .state-active { color: var(--accent); }
+      .state-todo { color: var(--fg-dim); }
+      .step .s-sub { color: var(--fg-dim); font-size: 12.5px; margin: 1px 0 0; }
+      .step .s-body { padding: 10px 0 14px; color: var(--fg-muted); font-size: 13.5px; }
+      .step .chev { width: 16px; height: 16px; color: var(--fg-dim); transition: transform .18s; }
+      .step details[open] .chev { transform: rotate(180deg); }
+
+      /* activity footer (current + A) */
+      .activity { margin-top: 22px; }
+      .activity-h { font-size: 13px; font-weight: 600; color: var(--fg); margin: 0 0 10px; }
+      .act-tabs { display: inline-flex; gap: 2px; padding: 3px; background: var(--card); border-radius: 9px; border: 1px solid var(--border-soft); margin-bottom: 14px; }
+      .act-tabs span { padding: 5px 12px; border-radius: 6px; font-size: 12.5px; color: var(--fg-muted); }
+      .act-tabs span.on { background: var(--modal); color: var(--fg); }
+      .act-empty { text-align: center; color: var(--fg-dim); padding: 22px 0; font-size: 13px; }
+      .act-empty svg { width: 26px; height: 26px; opacity: 0.5; margin-bottom: 8px; }
+
+      .note { background: var(--blue-bg); border: 1px solid var(--blue-border); color: var(--blue-fg); border-radius: 10px; padding: 12px 14px; font-size: 13px; margin: 14px 0 0; }
+      .note b { color: #d6e2fb; font-weight: 600; }
+      .divider { height: 1px; background: var(--border-soft); border: none; margin: 64px 0 0; }
+
+      .legend { display: flex; gap: 16px; flex-wrap: wrap; margin: 14px 0 0; font-size: 12px; color: var(--fg-dim); }
+      .legend span { display: inline-flex; align-items: center; gap: 6px; }
+      .swatch { width: 11px; height: 11px; border-radius: 3px; }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <!-- ════════════════ INTRO ════════════════ -->
+      <p class="eyebrow">Prototype · Legal document modal</p>
+      <h1 class="page-title font-safiro">Vänsterpanelen — bort från väggen av dragspel</h1>
+      <p class="page-sub">
+        Sex visuellt identiska dragspel staplade på varandra ger ingen hierarki och inga statussignaler
+        i hopfällt läge. Nedan: nuläget, följt av tre riktningar. Allt är klickbart.
+      </p>
+      <div class="legend">
+        <span><i class="swatch" style="background:var(--emerald)"></i> klar / ifylld</span>
+        <span><i class="swatch" style="background:var(--amber-fg)"></i> prioritet</span>
+        <span><i class="swatch" style="background:var(--fg-dim)"></i> tom / ej ifylld</span>
+        <span><i class="swatch" style="background:var(--accent)"></i> brand-accent</span>
+      </div>
+
+      <!-- ════════════════ CURRENT ════════════════ -->
+      <div class="variant-head first">
+        <span class="eyebrow">Nuläge</span>
+        <h2 class="variant-title">Sex dragspel + aktivitet</h2>
+        <p class="variant-desc">
+          Alla rader väger lika. Lagtext (referens), din egen analys och underlag ligger blandade.
+          Hopfällt avslöjar bara Kravpunkter och Filer något — resten måste man öppna för att se om de är tomma.
+        </p>
+      </div>
+
+      <div class="frame">
+        <div class="frame-bar">
+          <span class="crumb">Er laglista</span>
+          <i data-lucide="chevron-right"></i>
+          <span class="crumb"><b>SFS 2005:551</b></span>
+          <span class="spacer"></span>
+          <i data-lucide="share-2"></i>
+          <i data-lucide="more-horizontal"></i>
+          <i data-lucide="x"></i>
+        </div>
+        <div class="panel-pad">
+          <h3 class="law-title">Aktiebolagslag (2005:551)</h3>
+          <div class="badges">
+            <span class="pill pill-status"><i class="dot"></i> Ej påbörjad</span>
+            <span class="pill pill-priority"><i data-lucide="flag" class="ic"></i> Medel</span>
+            <button class="toggle-all"><i data-lucide="chevrons-up-down"></i></button>
+          </div>
+
+          <details class="acc">
+            <summary><span class="ttl"><i data-lucide="scale" class="lead"></i> Författningstext</span><span class="meta"><i data-lucide="chevron-down" class="chev"></i></span></summary>
+            <div class="body"><p>Lagtexten laddas här…</p></div>
+          </details>
+          <details class="acc" open>
+            <summary><span class="ttl"><i data-lucide="circle-help" class="lead"></i> Hur påverkar detta oss?</span><span class="meta"><i data-lucide="chevron-down" class="chev"></i></span></summary>
+            <div class="body"><p>Vi är ett aktiebolag och omfattas av reglerna om bolagsstyrning, styrelsens ansvar och årsredovisning.</p></div>
+          </details>
+          <details class="acc">
+            <summary><span class="ttl"><i data-lucide="file-text" class="lead"></i> Hur efterlever vi kraven?</span><span class="meta"><i data-lucide="chevron-down" class="chev"></i></span></summary>
+            <div class="body"><p class="empty-tag">Inget skrivet ännu.</p></div>
+          </details>
+          <details class="acc">
+            <summary><span class="ttl"><i data-lucide="clipboard-check" class="lead"></i> Kravpunkter</span><span class="meta"><span class="prog"><span class="lbl">1/3 uppfyllda</span><span class="track"><span class="fill" style="width:33%"></span></span></span><i data-lucide="chevron-down" class="chev"></i></span></summary>
+            <div class="body"><p>Checklistan…</p></div>
+          </details>
+          <details class="acc">
+            <summary><span class="ttl"><i data-lucide="list-checks" class="lead"></i> Uppgifter</span><span class="meta"><i data-lucide="chevron-down" class="chev"></i></span></summary>
+            <div class="body"><p class="empty-tag">Inga uppgifter än.</p></div>
+          </details>
+          <details class="acc">
+            <summary><span class="ttl"><i data-lucide="paperclip" class="lead"></i> Länkade filer &amp; dokument</span><span class="meta"><span class="count-chip">1</span><i data-lucide="chevron-down" class="chev"></i></span></summary>
+            <div class="body"><p>Bolagsordning_2024.pdf</p></div>
+          </details>
+
+          <div class="activity">
+            <p class="activity-h">Aktivitet</p>
+            <div class="act-tabs"><span class="on">Alla</span><span>Kommentarer</span><span>Historik</span></div>
+            <div class="act-empty"><div><i data-lucide="history"></i></div>Ingen aktivitet ännu</div>
+          </div>
+        </div>
+      </div>
+
+      <hr class="divider" />
+
+      <!-- ════════════════ VARIANT A ════════════════ -->
+      <div class="variant-head">
+        <span class="eyebrow">Riktning A</span>
+        <h2 class="variant-title">Grupperat + rika rader <span class="variant-tag rec">rekommenderad</span></h2>
+        <p class="variant-desc">
+          Samma dragspel, men chunkat i tre namngivna grupper och varje hopfälld rad bär sin status:
+          förhandstext, progress, antal, eller "ej ifylld". Du ser hela bilden utan att öppna något.
+          Lägst risk, störst skanbarhetsvinst.
+        </p>
+        <ul class="wins">
+          <li><i data-lucide="check"></i> Slutar med öppna/stäng-jonglering</li>
+          <li><i data-lucide="check"></i> Skiljer arbete från referens</li>
+          <li><i data-lucide="check"></i> Behåller befintlig kod-struktur</li>
+        </ul>
+      </div>
+
+      <div class="frame">
+        <div class="frame-bar">
+          <span class="crumb">Er laglista</span><i data-lucide="chevron-right"></i><span class="crumb"><b>SFS 2005:551</b></span>
+          <span class="spacer"></span><i data-lucide="share-2"></i><i data-lucide="more-horizontal"></i><i data-lucide="x"></i>
+        </div>
+        <div class="panel-pad">
+          <h3 class="law-title">Aktiebolagslag (2005:551)</h3>
+          <div class="badges">
+            <span class="pill pill-status"><i class="dot"></i> Ej påbörjad</span>
+            <span class="pill pill-priority"><i data-lucide="flag" class="ic"></i> Medel</span>
+            <button class="toggle-all"><i data-lucide="chevrons-up-down"></i></button>
+          </div>
+
+          <div class="group-label">Efterlevnad</div>
+
+          <details class="acc" open>
+            <summary>
+              <span class="ttl"><i data-lucide="circle-help" class="lead"></i> Hur påverkar detta oss?</span>
+              <span class="meta"><i data-lucide="chevron-down" class="chev"></i></span>
+            </summary>
+            <div class="body"><p>Vi är ett aktiebolag och omfattas av reglerna om bolagsstyrning, styrelsens ansvar och årsredovisning. Särskilt relevant är kapitel 7–8 om bolagsstämma och styrelse.</p></div>
+          </details>
+
+          <details class="acc">
+            <summary>
+              <span class="ttl"><i data-lucide="file-text" class="lead"></i> Hur efterlever vi kraven?</span>
+              <span class="meta"><span class="empty-tag">ej ifylld</span><i data-lucide="chevron-down" class="chev"></i></span>
+            </summary>
+            <div class="body"><p class="empty-tag">Beskriv hur ni efterlever lagen. <span style="color:var(--accent);cursor:pointer">Lägg till →</span></p></div>
+          </details>
+
+          <details class="acc">
+            <summary>
+              <span class="ttl"><i data-lucide="clipboard-check" class="lead"></i> Kravpunkter</span>
+              <span class="meta"><span class="prog"><span class="track"><span class="fill" style="width:33%"></span></span><span class="lbl">1/3</span></span><i data-lucide="chevron-down" class="chev"></i></span>
+            </summary>
+            <div class="body" style="padding-right:8px">
+              <div class="krav-row done"><span class="krav-box done"><i data-lucide="check"></i></span><span class="krav-txt">Registrerad bolagsordning hos Bolagsverket</span></div>
+              <div class="krav-row"><span class="krav-box"></span><span class="krav-txt">Styrelseprotokoll förs vid varje sammanträde</span></div>
+              <div class="krav-row"><span class="krav-box"></span><span class="krav-txt">Årsredovisning upprättas enligt ÅRL och ABL</span></div>
+            </div>
+          </details>
+
+          <div class="group-label">Referens</div>
+
+          <details class="acc">
+            <summary>
+              <span class="ttl"><i data-lucide="scale" class="lead"></i> Författningstext</span>
+              <span class="meta"><span style="color:var(--fg-dim)">SFS 2005:551</span><i data-lucide="arrow-up-right" class="chev"></i></span>
+            </summary>
+            <div class="body"><p>Öppnas i fokuserad läsvy. <span style="color:var(--accent);cursor:pointer">Visa fullständig lag →</span></p></div>
+          </details>
+
+          <div class="group-label">Underlag</div>
+
+          <details class="acc">
+            <summary>
+              <span class="ttl"><i data-lucide="list-checks" class="lead"></i> Uppgifter</span>
+              <span class="meta"><span class="empty-tag">inga än</span><i data-lucide="chevron-down" class="chev"></i></span>
+            </summary>
+            <div class="body"><p class="empty-tag">Inga uppgifter kopplade. <span style="color:var(--accent);cursor:pointer">Skapa uppgift →</span></p></div>
+          </details>
+
+          <details class="acc">
+            <summary>
+              <span class="ttl"><i data-lucide="paperclip" class="lead"></i> Länkade filer &amp; dokument</span>
+              <span class="meta"><span class="preview-line">Bolagsordning_2024.pdf</span><span class="count-chip">1</span><i data-lucide="chevron-down" class="chev"></i></span>
+            </summary>
+            <div class="body">
+              <div class="obj-row"><i data-lucide="file-text"></i><span class="name">Bolagsordning_2024.pdf</span><span class="sub">PDF · 240 kB</span></div>
+            </div>
+          </details>
+
+          <div class="activity">
+            <p class="activity-h">Aktivitet</p>
+            <div class="act-tabs"><span class="on">Alla</span><span>Kommentarer</span><span>Historik</span></div>
+            <div class="act-empty"><div><i data-lucide="history"></i></div>Ingen aktivitet ännu</div>
+          </div>
+        </div>
+      </div>
+
+      <hr class="divider" />
+
+      <!-- ════════════════ VARIANT B ════════════════ -->
+      <div class="variant-head">
+        <span class="eyebrow">Riktning B</span>
+        <h2 class="variant-title">Flikar i vänsterpanelen</h2>
+        <p class="variant-desc">
+          De sex dragspelen kollapsar till tre flikar: <b>Efterlevnad</b> (ditt arbete, alltid synligt),
+          <b>Lagtext</b> (full läsvy) och <b>Underlag</b> (uppgifter + filer, med antal). Ingen vägg, ingen scroll-jakt.
+        </p>
+        <ul class="wins">
+          <li><i data-lucide="check"></i> Eliminerar väggen helt</li>
+          <li><i data-lucide="check"></i> Lagtext får egen läsyta</li>
+          <li><i data-lucide="check"></i> Antal syns på fliken</li>
+        </ul>
+      </div>
+
+      <div class="frame">
+        <div class="frame-bar">
+          <span class="crumb">Er laglista</span><i data-lucide="chevron-right"></i><span class="crumb"><b>SFS 2005:551</b></span>
+          <span class="spacer"></span><i data-lucide="share-2"></i><i data-lucide="more-horizontal"></i><i data-lucide="x"></i>
+        </div>
+        <div class="panel-pad" data-tabs>
+          <h3 class="law-title">Aktiebolagslag (2005:551)</h3>
+          <div class="badges">
+            <span class="pill pill-status"><i class="dot"></i> Ej påbörjad</span>
+            <span class="pill pill-priority"><i data-lucide="flag" class="ic"></i> Medel</span>
+          </div>
+
+          <div class="tabbar">
+            <button class="tab active" data-tab="eff"><i data-lucide="clipboard-check"></i> Efterlevnad</button>
+            <button class="tab" data-tab="law"><i data-lucide="scale"></i> Lagtext</button>
+            <button class="tab" data-tab="und"><i data-lucide="paperclip"></i> Underlag <span class="badge">1</span></button>
+          </div>
+
+          <!-- Efterlevnad -->
+          <div class="tabpane active" data-pane="eff">
+            <div class="field-label"><i data-lucide="circle-help" class="lead"></i> Hur påverkar detta oss?</div>
+            <div class="field-box">Vi är ett aktiebolag och omfattas av reglerna om bolagsstyrning, styrelsens ansvar och årsredovisning. Särskilt relevant är kapitel 7–8 om bolagsstämma och styrelse.</div>
+
+            <div class="field-label"><i data-lucide="file-text" class="lead"></i> Hur efterlever vi kraven?</div>
+            <div class="field-box empty">Inget skrivet ännu — klicka för att beskriva er efterlevnad.</div>
+
+            <div class="field-label" style="margin-top:22px;justify-content:space-between">
+              <span style="display:inline-flex;align-items:center;gap:8px"><i data-lucide="clipboard-check" class="lead"></i> Kravpunkter</span>
+              <span class="prog"><span class="track"><span class="fill" style="width:33%"></span></span><span class="lbl">1/3 uppfyllda</span></span>
+            </div>
+            <div class="field-box" style="padding:6px 14px">
+              <div class="krav-row done"><span class="krav-box done"><i data-lucide="check"></i></span><span class="krav-txt">Registrerad bolagsordning hos Bolagsverket</span></div>
+              <div class="krav-row"><span class="krav-box"></span><span class="krav-txt">Styrelseprotokoll förs vid varje sammanträde</span></div>
+              <div class="krav-row"><span class="krav-box"></span><span class="krav-txt">Årsredovisning upprättas enligt ÅRL och ABL</span></div>
+            </div>
+          </div>
+
+          <!-- Lagtext -->
+          <div class="tabpane" data-pane="law">
+            <div class="lagtext-reader">
+              <div class="para"><h4>1 kap. Inledande bestämmelser</h4>Denna lag innehåller bestämmelser om aktiebolag. Bestämmelserna avser bildande av aktiebolag, bolagsordning, aktier samt aktiebok.</div>
+              <div class="para"><h4>7 kap. Bolagsstämma</h4>Aktieägarnas rätt att besluta i bolagets angelägenheter utövas vid bolagsstämman. Bolagsstämman ska hållas inom sex månader från räkenskapsårets utgång.</div>
+              <div class="para"><h4>8 kap. Bolagets ledning</h4>Ett aktiebolag ska ha en styrelse med en eller flera ledamöter. Styrelsen svarar för bolagets organisation och förvaltningen av bolagets angelägenheter.</div>
+            </div>
+            <p style="text-align:center;margin:14px 0 0"><span style="color:var(--accent);cursor:pointer;font-size:13px">Visa fullständig lag →</span></p>
+          </div>
+
+          <!-- Underlag -->
+          <div class="tabpane" data-pane="und">
+            <div class="field-label"><i data-lucide="list-checks" class="lead"></i> Uppgifter <span class="empty-tag" style="margin-left:6px;font-weight:400">inga än</span></div>
+            <div class="field-box empty">Inga uppgifter kopplade till denna lag. Skapa en uppgift →</div>
+
+            <div class="field-label"><i data-lucide="paperclip" class="lead"></i> Länkade filer &amp; dokument</div>
+            <div class="obj-row"><i data-lucide="file-text"></i><span class="name">Bolagsordning_2024.pdf</span><span class="sub">PDF · 240 kB</span></div>
+          </div>
+        </div>
+      </div>
+
+      <hr class="divider" />
+
+      <!-- ════════════════ VARIANT C ════════════════ -->
+      <div class="variant-head">
+        <span class="eyebrow">Riktning C</span>
+        <h2 class="variant-title">Vägledd arbetsgång (stepper)</h2>
+        <p class="variant-desc">
+          Panelen blir ett numrerat compliance-flöde med status per steg (klar / pågår / att göra).
+          Lär ut den avsedda ordningen och visar progress på en blick. Störst konceptuellt skifte.
+        </p>
+        <ul class="wins">
+          <li><i data-lucide="check"></i> Synliggör arbetsordningen</li>
+          <li><i data-lucide="check"></i> Status per steg på en blick</li>
+          <li><i data-lucide="check"></i> Bra för nya användare</li>
+        </ul>
+      </div>
+
+      <div class="frame">
+        <div class="frame-bar">
+          <span class="crumb">Er laglista</span><i data-lucide="chevron-right"></i><span class="crumb"><b>SFS 2005:551</b></span>
+          <span class="spacer"></span><i data-lucide="share-2"></i><i data-lucide="more-horizontal"></i><i data-lucide="x"></i>
+        </div>
+        <div class="panel-pad">
+          <h3 class="law-title">Aktiebolagslag (2005:551)</h3>
+          <div class="badges">
+            <span class="pill pill-status"><i class="dot"></i> Ej påbörjad</span>
+            <span class="pill pill-priority"><i data-lucide="flag" class="ic"></i> Medel</span>
+          </div>
+
+          <div style="margin-top:6px">
+            <!-- Step 1 -->
+            <div class="step">
+              <span class="step-node done"><i data-lucide="check"></i></span>
+              <details>
+                <summary>
+                  <div><span class="s-ttl">Förstå lagen</span><p class="s-sub">Lagtext · hur den påverkar oss</p></div>
+                  <span class="s-state state-done">klar <i data-lucide="chevron-down" class="chev"></i></span>
+                </summary>
+                <div class="s-body">
+                  <p style="margin:0 0 8px">Vi är ett aktiebolag och omfattas av reglerna om bolagsstyrning, styrelsens ansvar och årsredovisning.</p>
+                  <span style="color:var(--accent);cursor:pointer;font-size:13px">Läs författningstexten →</span>
+                </div>
+              </details>
+            </div>
+
+            <!-- Step 2 (active, open) -->
+            <div class="step">
+              <span class="step-node active">2</span>
+              <details open>
+                <summary>
+                  <div><span class="s-ttl">Beskriv efterlevnad</span><p class="s-sub">Hur efterlever vi kraven?</p></div>
+                  <span class="s-state state-active">pågår <i data-lucide="chevron-down" class="chev"></i></span>
+                </summary>
+                <div class="s-body">
+                  <div class="field-box empty">Inget skrivet ännu — beskriv hur ni efterlever lagen.</div>
+                </div>
+              </details>
+            </div>
+
+            <!-- Step 3 -->
+            <div class="step">
+              <span class="step-node">3</span>
+              <details>
+                <summary>
+                  <div><span class="s-ttl">Kravpunkter</span><p class="s-sub">Bocka av konkreta krav</p></div>
+                  <span class="s-state state-active"><span class="prog"><span class="track"><span class="fill" style="width:33%"></span></span><span class="lbl">1/3</span></span> <i data-lucide="chevron-down" class="chev"></i></span>
+                </summary>
+                <div class="s-body">
+                  <div class="krav-row done"><span class="krav-box done"><i data-lucide="check"></i></span><span class="krav-txt">Registrerad bolagsordning hos Bolagsverket</span></div>
+                  <div class="krav-row"><span class="krav-box"></span><span class="krav-txt">Styrelseprotokoll förs vid varje sammanträde</span></div>
+                  <div class="krav-row"><span class="krav-box"></span><span class="krav-txt">Årsredovisning upprättas enligt ÅRL och ABL</span></div>
+                </div>
+              </details>
+            </div>
+
+            <!-- Step 4 -->
+            <div class="step">
+              <span class="step-node">4</span>
+              <details>
+                <summary>
+                  <div><span class="s-ttl">Åtgärder &amp; bevis</span><p class="s-sub">Uppgifter och länkade filer</p></div>
+                  <span class="s-state state-todo">1 objekt <i data-lucide="chevron-down" class="chev"></i></span>
+                </summary>
+                <div class="s-body">
+                  <div class="obj-row" style="margin-bottom:8px"><i data-lucide="list-checks"></i><span class="name">Inga uppgifter än</span><span class="sub">skapa →</span></div>
+                  <div class="obj-row"><i data-lucide="file-text"></i><span class="name">Bolagsordning_2024.pdf</span><span class="sub">PDF · 240 kB</span></div>
+                </div>
+              </details>
+            </div>
+          </div>
+
+          <div class="note">
+            <b>Obs:</b> Aktivitet (kommentarer/historik) flyttas lämpligen till höger panel eller en
+            egen flik i denna variant, så flödet på vänster sida förblir rent.
+          </div>
+        </div>
+      </div>
+
+    </div>
+
+    <script>
+      lucide.createIcons();
+      // Tab switching (Variant B)
+      document.querySelectorAll('[data-tabs]').forEach((root) => {
+        root.querySelectorAll('.tab').forEach((btn) => {
+          btn.addEventListener('click', () => {
+            const id = btn.dataset.tab;
+            root.querySelectorAll('.tab').forEach((b) => b.classList.toggle('active', b === btn));
+            root.querySelectorAll('.tabpane').forEach((p) => p.classList.toggle('active', p.dataset.pane === id));
+          });
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/_prototypes/split-screen-login-changelog.html
+++ b/_prototypes/split-screen-login-changelog.html
@@ -1,0 +1,511 @@
+<!doctype html>
+<html lang="sv">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Split-screen login + förändringslogg (prototype)</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
+    <style>
+      /* Real brand fonts — loaded straight from /public like the other prototypes. */
+      @font-face {
+        font-family: 'Safiro';
+        src:
+          url('../public/fonts/safiro-medium-webfont.woff2') format('woff2'),
+          url('../public/fonts/safiro-medium-webfont.woff') format('woff');
+        font-weight: 500; font-style: normal; font-display: swap;
+      }
+      @font-face {
+        font-family: 'Google Sans Flex';
+        src: url('../public/fonts/GoogleSansFlex.ttf') format('truetype');
+        font-weight: 100 900; font-style: normal; font-display: swap;
+      }
+
+      /* Light-mode tokens — hex approximations of globals.css :root (warm palette). */
+      :root {
+        --background:        #fbfaf5;
+        --foreground:        #1c1916;
+        --card:              #fdfcfa;
+        --primary:           #231f1a;
+        --primary-fg:        #fbfaf5;
+        --secondary:         #f4f1eb;
+        --muted:             #f1eee8;
+        --muted-fg:          #7c756b;
+        --accent:            #efebe3;
+        --border:            #e5e0d8;
+        --input-border:      #ddd6cc;
+        --ring:              #231f1a;
+        --destructive:       #e0463b;
+        --section-warm:      #f6f1e7;
+        --sage:              #4a9b6e;   /* chart-2 */
+        --amber:             #c79433;   /* chart-1, darkened for light bg */
+        --info:              #2552d6;
+
+        /* Left panel — barely-warmer cream than the form side, like the v3 hero
+           background. The split reads from a hairline + a whisper of warmth, not
+           a colored slab. */
+        --panel:             #f4efe4;   /* soft warm cream */
+        --panel-deep:        #efe8da;   /* a touch deeper toward the corner */
+        --panel-fg:          #221d16;   /* warm near-black ink */
+        --panel-dim:         #6f685c;   /* warm muted */
+        --panel-dimmer:      #968d7d;
+        --panel-hair:        rgba(34, 29, 22, 0.10);
+        --panel-line:        rgba(34, 29, 22, 0.13);
+
+        /* Near-monochrome, like the v3 hero: warm ink + grays, with a single
+           amber accent reserved for the one "live" ping. Nothing else colored. */
+        --amber-600:         #d97706;   /* the only accent on the whole panel */
+      }
+
+      * { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; height: 100%; }
+      body {
+        font-family: 'Google Sans Flex', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+        font-size: 14px;
+        line-height: 1.5;
+        color: var(--foreground);
+        background:
+          radial-gradient(1100px 700px at 78% 18%, #f3ecdd 0%, transparent 60%),
+          radial-gradient(900px 600px at 12% 92%, #efe7d6 0%, transparent 55%),
+          var(--section-warm);
+        -webkit-font-smoothing: antialiased;
+        min-height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 40px 24px;
+      }
+      .font-safiro { font-family: 'Safiro', system-ui, sans-serif; }
+
+      /* ---- The floating split card ---- */
+      .auth-card {
+        width: 100%;
+        max-width: 1120px;
+        min-height: 680px;
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: 22px;
+        overflow: hidden;
+        display: grid;
+        grid-template-columns: 1.08fr 1fr;
+        box-shadow:
+          0 1px 0 rgba(255,255,255,0.7) inset,
+          0 28px 70px -32px rgba(40, 30, 16, 0.40),
+          0 8px 24px -16px rgba(40, 30, 16, 0.28);
+      }
+
+      /* ============ LEFT: changelog panel ============ */
+      .panel {
+        position: relative;
+        border-right: 1px solid var(--border);
+        /* Whisper-soft warm gradient only — a light top-right wash and a hair
+           more warmth in the bottom corner. No colored glow (matches the v3
+           hero's near-flat warm-cream field). */
+        background:
+          radial-gradient(700px 520px at 84% 4%, rgba(255, 255, 255, 0.6) 0%, transparent 58%),
+          radial-gradient(760px 660px at 98% 104%, rgba(231, 221, 199, 0.55) 0%, transparent 60%),
+          linear-gradient(160deg, var(--panel) 0%, var(--panel-deep) 100%);
+        color: var(--panel-fg);
+        padding: 40px 44px 36px;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+      }
+      /* One soft, oversized blob for organic depth — a Laglig "mesh" gesture. */
+      .panel::after {
+        content: "";
+        position: absolute;
+        width: 460px; height: 460px;
+        right: -160px; bottom: -180px;
+        border-radius: 50% 46% 54% 48%;
+        background: radial-gradient(circle at 35% 35%, rgba(255,255,255,0.5), transparent 62%);
+        filter: blur(2px);
+        pointer-events: none;
+      }
+      .panel > * { position: relative; z-index: 1; }
+
+      /* Black wordmark on the light panel (logo asset is white → flip to ink).
+         align-self:flex-start stops the column-flex from stretching the img. */
+      .panel__brand {
+        width: 104px; height: auto; display: block;
+        align-self: flex-start;
+        filter: brightness(0);
+      }
+
+      .panel__head { margin-top: 44px; }
+      .eyebrow {
+        display: inline-flex; align-items: center; gap: 7px;
+        font-size: 11px; font-weight: 600;
+        letter-spacing: 0.14em; text-transform: uppercase;
+        color: var(--panel-dim);
+      }
+      /* Amber ping — same gesture as the v3 hero's "10 000+ lagar" callout. */
+      .eyebrow .dot-pulse {
+        width: 7px; height: 7px; border-radius: 999px; background: var(--amber-600);
+        box-shadow: 0 0 0 0 rgba(245,158,11,0.6);
+        animation: pulse 2.6s ease-out infinite;
+      }
+      @keyframes pulse {
+        0%   { box-shadow: 0 0 0 0 rgba(245,158,11,0.5); }
+        70%  { box-shadow: 0 0 0 8px rgba(245,158,11,0); }
+        100% { box-shadow: 0 0 0 0 rgba(245,158,11,0); }
+      }
+      .panel__title {
+        font-family: 'Safiro', system-ui, sans-serif;
+        font-weight: 500;
+        font-size: 30px;
+        line-height: 1.12;
+        letter-spacing: -0.01em;
+        margin: 12px 0 6px;
+      }
+      .panel__sub { color: var(--panel-dim); font-size: 14px; max-width: 38ch; }
+
+      /* ---- shadcn-style vertical Timeline ---- */
+      .timeline {
+        list-style: none;
+        margin: 30px 0 0;
+        padding: 0;
+        flex: 1;
+        min-height: 0;
+        overflow-y: auto;
+        -webkit-mask-image: linear-gradient(to bottom, transparent 0, #000 14px, #000 calc(100% - 18px), transparent 100%);
+        mask-image: linear-gradient(to bottom, transparent 0, #000 14px, #000 calc(100% - 18px), transparent 100%);
+        scrollbar-width: thin;
+        scrollbar-color: var(--panel-line) transparent;
+      }
+      .timeline::-webkit-scrollbar { width: 6px; }
+      .timeline::-webkit-scrollbar-thumb { background: var(--panel-line); border-radius: 999px; }
+
+      .t-item {
+        position: relative;
+        padding: 0 0 22px 30px;
+        opacity: 0;
+        animation: rise 0.55s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+      }
+      .t-item:last-child { padding-bottom: 4px; }
+      /* connecting line between dots */
+      .t-item::before {
+        content: "";
+        position: absolute;
+        left: 5px; top: 5px; bottom: -5px;
+        width: 1.5px;
+        background: var(--panel-line);
+      }
+      .t-item:last-child::before { display: none; }
+      /* Uniform monochrome ink dots — the pill label carries the category,
+         not colour. (No amber here; that's reserved for the eyebrow ping.) */
+      .t-dot {
+        position: absolute;
+        left: 0; top: 3px;
+        width: 10px; height: 10px;
+        border-radius: 999px;
+        background: var(--panel-fg);
+        box-shadow: 0 0 0 4px rgba(34,29,22,0.05);
+      }
+
+      .t-meta { display: flex; align-items: center; gap: 9px; margin-bottom: 4px; }
+      .t-date {
+        font-size: 11.5px;
+        font-variant-numeric: tabular-nums;
+        letter-spacing: 0.02em;
+        color: var(--panel-dimmer);
+      }
+      /* Uniform neutral outline pills — monochrome, the label carries the type.
+         (v3 restraint: amber is reserved for the dots, not sprayed on tags.) */
+      .tag {
+        font-size: 10.5px; font-weight: 600;
+        letter-spacing: 0.06em; text-transform: uppercase;
+        padding: 2px 9px; border-radius: 999px;
+        color: var(--panel-dim);
+        background: rgba(34, 29, 22, 0.02);
+        border: 1px solid var(--panel-line);
+      }
+
+      .t-title { font-size: 14.5px; font-weight: 600; margin: 0 0 3px; color: var(--panel-fg); }
+      .t-desc  { font-size: 13px; color: var(--panel-dim); margin: 0; max-width: 46ch; }
+
+      .panel__foot {
+        margin-top: 22px;
+        padding-top: 18px;
+        border-top: 1px solid var(--panel-hair);
+        display: flex; align-items: center; justify-content: space-between;
+      }
+      .panel__foot .ver { font-size: 12px; color: var(--panel-dimmer); }
+      .see-all {
+        display: inline-flex; align-items: center; gap: 6px;
+        font-size: 13px; font-weight: 600; color: var(--panel-fg);
+        text-decoration: none; opacity: 0.9;
+        transition: gap 0.18s ease, opacity 0.18s ease;
+      }
+      .see-all:hover { opacity: 1; gap: 9px; }
+      .see-all svg { width: 15px; height: 15px; }
+
+      /* ============ RIGHT: login form ============ */
+      .form-wrap {
+        display: flex; align-items: center; justify-content: center;
+        padding: 48px 56px;
+      }
+      .form { width: 100%; max-width: 372px; }
+      .form__h1 {
+        font-family: 'Safiro', system-ui, sans-serif;
+        font-weight: 500;
+        font-size: 30px;
+        letter-spacing: -0.01em;
+        margin: 0 0 6px;
+        color: var(--foreground);
+      }
+      .form__sub { color: var(--muted-fg); font-size: 14.5px; margin: 0 0 28px; }
+
+      .field { margin-bottom: 16px; }
+      .field label {
+        display: block; font-size: 13px; font-weight: 500;
+        margin-bottom: 7px; color: var(--foreground);
+      }
+      .input-shell { position: relative; }
+      .input {
+        width: 100%; height: 44px;
+        padding: 0 14px;
+        background: #fff;
+        border: 1px solid var(--input-border);
+        border-radius: 10px;
+        font-size: 14px; color: var(--foreground);
+        outline: none;
+        transition: border-color 0.16s ease, box-shadow 0.16s ease;
+      }
+      .input::placeholder { color: #b3a99c; }
+      .input:focus {
+        border-color: var(--ring);
+        box-shadow: 0 0 0 3px rgba(35, 31, 26, 0.10);
+      }
+      .input.has-trail { padding-right: 44px; }
+      .trail-btn {
+        position: absolute; right: 6px; top: 50%; transform: translateY(-50%);
+        height: 32px; width: 32px;
+        display: flex; align-items: center; justify-content: center;
+        border: 0; background: transparent; cursor: pointer;
+        color: var(--muted-fg); border-radius: 8px;
+      }
+      .trail-btn:hover { background: var(--muted); color: var(--foreground); }
+      .trail-btn svg { width: 17px; height: 17px; }
+
+      .row-between { display: flex; align-items: center; justify-content: space-between; margin: 4px 0 22px; }
+      .check { display: inline-flex; align-items: center; gap: 9px; cursor: pointer; user-select: none; }
+      .check input { position: absolute; opacity: 0; width: 0; height: 0; }
+      .check__box {
+        width: 17px; height: 17px; border-radius: 5px;
+        border: 1.5px solid var(--input-border); background: #fff;
+        display: inline-flex; align-items: center; justify-content: center;
+        transition: all 0.14s ease;
+      }
+      .check__box svg { width: 12px; height: 12px; color: var(--primary-fg); opacity: 0; }
+      .check input:checked + .check__box { background: var(--primary); border-color: var(--primary); }
+      .check input:checked + .check__box svg { opacity: 1; }
+      .check span { font-size: 13.5px; color: var(--foreground); }
+      .link { font-size: 13.5px; font-weight: 500; color: var(--foreground); text-decoration: none; }
+      .link:hover { color: var(--muted-fg); }
+
+      .btn-primary {
+        width: 100%; height: 46px;
+        background: var(--primary); color: var(--primary-fg);
+        border: 0; border-radius: 10px;
+        font-size: 14.5px; font-weight: 600; cursor: pointer;
+        box-shadow: 0 10px 24px -10px rgba(35, 31, 26, 0.45);
+        transition: transform 0.12s ease, box-shadow 0.16s ease, background 0.16s ease;
+      }
+      .btn-primary:hover { box-shadow: 0 14px 30px -10px rgba(35, 31, 26, 0.55); transform: translateY(-1px); }
+      .btn-primary:active { transform: translateY(0); }
+
+      .btn-google {
+        width: 100%; height: 46px;
+        display: flex; align-items: center; justify-content: center; gap: 10px;
+        background: #fff; color: var(--foreground);
+        border: 1px solid var(--input-border); border-radius: 10px;
+        font-size: 14px; font-weight: 500; cursor: pointer;
+        transition: background 0.14s ease, border-color 0.14s ease;
+      }
+      .btn-google:hover { background: var(--secondary); border-color: var(--border); }
+      .btn-google svg { width: 18px; height: 18px; }
+
+      .divider { display: flex; align-items: center; gap: 14px; margin: 20px 0; }
+      .divider::before, .divider::after { content: ""; flex: 1; height: 1px; background: var(--border); }
+      .divider span { font-size: 11px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--muted-fg); }
+
+      .signup-line { text-align: center; font-size: 14px; color: var(--muted-fg); margin: 26px 0 0; }
+      .signup-line a { color: var(--foreground); font-weight: 600; text-decoration: none; }
+      .signup-line a:hover { text-decoration: underline; }
+
+      .terms { text-align: center; font-size: 11.5px; line-height: 1.6; color: var(--muted-fg); margin: 22px 0 0; }
+      .terms a { color: var(--muted-fg); text-decoration: underline; }
+
+      /* entrance */
+      @keyframes rise { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: none; } }
+      .form { animation: rise 0.6s cubic-bezier(0.22,1,0.36,1) both; }
+
+      /* annotation caption */
+      .caption {
+        position: fixed; left: 50%; bottom: 16px; transform: translateX(-50%);
+        display: inline-flex; align-items: center; gap: 8px;
+        font-size: 12px; color: var(--muted-fg);
+        background: rgba(255,255,255,0.7); backdrop-filter: blur(6px);
+        border: 1px dashed var(--border); border-radius: 999px;
+        padding: 6px 14px;
+      }
+      .caption b { color: var(--foreground); font-weight: 600; }
+
+      /* ---- responsive: collapse to single-column form under lg ---- */
+      @media (max-width: 980px) {
+        body { padding: 24px 16px; align-items: stretch; }
+        .auth-card { grid-template-columns: 1fr; max-width: 440px; min-height: 0; margin: auto; }
+        .panel { display: none; }
+        .form-wrap { padding: 40px 32px; }
+        .caption { display: none; }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="auth-card">
+      <!-- ============ LEFT: changelog / version history ============ -->
+      <aside class="panel">
+        <img class="panel__brand" src="../public/images/logo-final.png" alt="Laglig.se" />
+
+        <div class="panel__head">
+          <span class="eyebrow"><span class="dot-pulse"></span> Förändringslogg</span>
+          <h2 class="panel__title">Nytt i Laglig</h2>
+          <p class="panel__sub">Vi förbättrar plattformen varje vecka. Här är de senaste uppdateringarna.</p>
+        </div>
+
+        <ol class="timeline">
+          <li class="t-item" style="animation-delay: 0.05s">
+            <span class="t-dot new"></span>
+            <div class="t-meta">
+              <time class="t-date">20 maj 2026</time>
+              <span class="tag new">Nyhet</span>
+            </div>
+            <h4 class="t-title">AI-sammanfattning av lagändringar</h4>
+            <p class="t-desc">Få en kort, källhänvisad sammanfattning av vad varje ny föreskrift faktiskt innebär för er verksamhet.</p>
+          </li>
+
+          <li class="t-item" style="animation-delay: 0.12s">
+            <span class="t-dot improve"></span>
+            <div class="t-meta">
+              <time class="t-date">12 maj 2026</time>
+              <span class="tag improve">Förbättring</span>
+            </div>
+            <h4 class="t-title">Snabbare laglistor</h4>
+            <p class="t-desc">Laddningstiden för stora laglistor har mer än halverats — även med tusentals krav.</p>
+          </li>
+
+          <li class="t-item" style="animation-delay: 0.19s">
+            <span class="t-dot new"></span>
+            <div class="t-meta">
+              <time class="t-date">5 maj 2026</time>
+              <span class="tag new">Nyhet</span>
+            </div>
+            <h4 class="t-title">Efterlevnadspartnern i chatten</h4>
+            <p class="t-desc">Ställ frågor om era krav direkt till AI-partnern och få svar med hänvisning till rätt paragraf.</p>
+          </li>
+
+          <li class="t-item" style="animation-delay: 0.26s">
+            <span class="t-dot improve"></span>
+            <div class="t-meta">
+              <time class="t-date">28 apr 2026</time>
+              <span class="tag improve">Förbättring</span>
+            </div>
+            <h4 class="t-title">Versionshistorik på uppladdade filer</h4>
+            <p class="t-desc">Ladda upp underlag per krav och bläddra tillbaka till tidigare versioner när som helst.</p>
+          </li>
+
+          <li class="t-item" style="animation-delay: 0.33s">
+            <span class="t-dot fix"></span>
+            <div class="t-meta">
+              <time class="t-date">20 apr 2026</time>
+              <span class="tag fix">Åtgärdat</span>
+            </div>
+            <h4 class="t-title">Export till Excel</h4>
+            <p class="t-desc">Rättat ett fel där datumkolumner ibland exporterades i fel format vid stora urval.</p>
+          </li>
+        </ol>
+
+        <div class="panel__foot">
+          <span class="ver">Version 2.14</span>
+          <a class="see-all" href="#">Se alla uppdateringar <i data-lucide="arrow-right"></i></a>
+        </div>
+      </aside>
+
+      <!-- ============ RIGHT: login form ============ -->
+      <section class="form-wrap">
+        <form class="form" onsubmit="return false">
+          <h1 class="form__h1">Välkommen tillbaka</h1>
+          <p class="form__sub">Logga in för att fortsätta till Laglig.se</p>
+
+          <button type="button" class="btn-google">
+            <svg viewBox="0 0 48 48" aria-hidden="true">
+              <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"/>
+              <path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"/>
+              <path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"/>
+              <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"/>
+            </svg>
+            Fortsätt med Google
+          </button>
+
+          <div class="divider"><span>eller</span></div>
+
+          <div class="field">
+            <label for="email">E-postadress</label>
+            <div class="input-shell">
+              <input class="input" id="email" type="email" placeholder="namn@foretag.se" autocomplete="email" />
+            </div>
+          </div>
+
+          <div class="field">
+            <label for="password">Lösenord</label>
+            <div class="input-shell">
+              <input class="input has-trail" id="password" type="password" placeholder="••••••••" autocomplete="current-password" />
+              <button type="button" class="trail-btn" id="togglePw" aria-label="Visa lösenord">
+                <i data-lucide="eye"></i>
+              </button>
+            </div>
+          </div>
+
+          <div class="row-between">
+            <label class="check">
+              <input type="checkbox" id="remember" />
+              <span class="check__box"><i data-lucide="check"></i></span>
+              <span>Kom ihåg min e-post</span>
+            </label>
+            <a class="link" href="#">Glömt lösenordet?</a>
+          </div>
+
+          <button type="submit" class="btn-primary">Logga in</button>
+
+          <p class="signup-line">Inget konto? <a href="#">Skapa ett konto</a></p>
+
+          <p class="terms">
+            Genom att logga in accepterar du Laglig.se:s
+            <a href="#">Användarvillkor</a> och <a href="#">Integritetspolicy</a>.
+          </p>
+        </form>
+      </section>
+    </main>
+
+    <div class="caption">
+      <b>Prototyp</b> · split-screen login · timeline = shadcn-style <b>Timeline</b>-komponent
+    </div>
+
+    <script>
+      lucide.createIcons();
+
+      // password show / hide
+      const pw = document.getElementById('password');
+      const toggle = document.getElementById('togglePw');
+      toggle.addEventListener('click', () => {
+        const show = pw.type === 'password';
+        pw.type = show ? 'text' : 'password';
+        toggle.innerHTML = show
+          ? '<i data-lucide="eye-off"></i>'
+          : '<i data-lucide="eye"></i>';
+        lucide.createIcons();
+      });
+    </script>
+  </body>
+</html>

--- a/app/(workspace)/filer/_components/documents-browser.tsx
+++ b/app/(workspace)/filer/_components/documents-browser.tsx
@@ -10,6 +10,7 @@ import { useState, useCallback, useMemo, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { useSWRConfig } from 'swr'
 import { Button } from '@/components/ui/button'
+import { EmptyState } from '@/components/ui/empty-state'
 import { Input } from '@/components/ui/input'
 import { Checkbox } from '@/components/ui/checkbox'
 import {
@@ -681,22 +682,34 @@ export default function DocumentsBrowser({
               ))}
             </div>
           ) : folders.length === 0 && files.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-16 text-center">
-              <FolderOpen className="h-16 w-16 text-muted-foreground/30 mb-4" />
-              <h3 className="text-lg font-medium">Tom mapp</h3>
-              <p className="text-sm text-muted-foreground mt-1 mb-4">
-                Ladda upp filer eller skapa en ny mapp för att komma igång.
-              </p>
-              <Button
-                variant="outline"
-                onClick={() =>
-                  document.getElementById('file-upload-input')?.click()
-                }
-              >
-                <Upload className="h-4 w-4 mr-2" />
-                Ladda upp filer
-              </Button>
-            </div>
+            <EmptyState
+              icon={
+                <EmptyState.Icon>
+                  <FolderOpen className="h-8 w-8 text-muted-foreground" />
+                </EmptyState.Icon>
+              }
+              title="Inga filer ännu"
+              description="Ladda upp filer eller skapa en mapp för att börja organisera era dokument."
+              action={
+                <div className="flex gap-2">
+                  <Button
+                    onClick={() =>
+                      document.getElementById('file-upload-input')?.click()
+                    }
+                  >
+                    <Upload className="h-4 w-4 mr-2" />
+                    Ladda upp filer
+                  </Button>
+                  <Button
+                    variant="outline"
+                    onClick={() => setIsCreatingFolder(true)}
+                  >
+                    <FolderPlus className="h-4 w-4 mr-2" />
+                    Ny mapp
+                  </Button>
+                </div>
+              }
+            />
           ) : viewMode === 'grid' ? (
             <div
               className="grid gap-5"

--- a/app/actions/document-list.ts
+++ b/app/actions/document-list.ts
@@ -103,6 +103,10 @@ export interface DocumentListItem {
   updatedAt: Date
   // Story 8.1: Pending change count for visual indicators
   pendingChangeCount: number
+  // Kravpunkter progress, batched server-side so the table renders the count
+  // pill without a per-row server-action fetch (see getDocumentListItems).
+  requirementTotal: number
+  requirementFulfilled: number
   document: {
     id: string
     title: string
@@ -480,6 +484,40 @@ export async function getDocumentListItems(
         changeCountMap.set(row.document_id, Number(row.count))
       }
 
+      // Kravpunkter counts: batched once for the whole page instead of one
+      // server action per row. Keyed on the already workspace-scoped list-item
+      // ids (same pattern as the change counts above). Indexed by
+      // law_list_item_requirements(list_item_id, position).
+      const listItemIds = itemsToReturn.map((item) => item.id)
+      const requirementCounts =
+        listItemIds.length > 0
+          ? await prisma.$queryRaw<
+              Array<{
+                list_item_id: string
+                total: bigint
+                fulfilled: bigint
+              }>
+            >`
+              SELECT list_item_id,
+                     COUNT(*) AS total,
+                     COUNT(*) FILTER (WHERE is_fulfilled) AS fulfilled
+              FROM law_list_item_requirements
+              WHERE list_item_id = ANY(${listItemIds}::text[])
+              GROUP BY list_item_id
+            `
+          : []
+
+      const requirementCountMap = new Map<
+        string,
+        { total: number; fulfilled: number }
+      >()
+      for (const row of requirementCounts) {
+        requirementCountMap.set(row.list_item_id, {
+          total: Number(row.total),
+          fulfilled: Number(row.fulfilled),
+        })
+      }
+
       return {
         success: true,
         data: {
@@ -525,6 +563,10 @@ export async function getDocumentListItems(
             updatedAt: item.updated_at,
             // Story 8.1: Pending change count for visual indicators
             pendingChangeCount: changeCountMap.get(item.document_id) ?? 0,
+            // Kravpunkter progress (batched above) for the table count pill.
+            requirementTotal: requirementCountMap.get(item.id)?.total ?? 0,
+            requirementFulfilled:
+              requirementCountMap.get(item.id)?.fulfilled ?? 0,
             document: {
               id: item.document.id,
               title: item.document.title,

--- a/components/features/compliance-audit/cycle-list/cycle-list-table.tsx
+++ b/components/features/compliance-audit/cycle-list/cycle-list-table.tsx
@@ -17,7 +17,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { format } from 'date-fns'
 import { sv } from 'date-fns/locale'
-import { Plus } from 'lucide-react'
+import { Plus, ClipboardCheck } from 'lucide-react'
 import {
   Table,
   TableBody,
@@ -257,24 +257,34 @@ function EmptyState({
   canCreate: boolean
 }) {
   const isActiveFilter = filter === 'aktiva'
+  if (isActiveFilter) {
+    return (
+      <SharedEmptyState
+        className="rounded-md border"
+        icon={
+          <SharedEmptyState.Icon>
+            <ClipboardCheck className="h-8 w-8 text-muted-foreground" />
+          </SharedEmptyState.Icon>
+        }
+        title="Inga kontroller ännu"
+        description="Skapa en efterlevnadskontroll för att visa att ni faktiskt lever upp till lagkraven — och få en delbar rapport på köpet."
+        action={
+          canCreate ? (
+            <Button asChild>
+              <Link href="/laglistor/kontroller/skapa">
+                <Plus className="mr-1.5 h-4 w-4" aria-hidden="true" />
+                Skapa kontroll
+              </Link>
+            </Button>
+          ) : undefined
+        }
+      />
+    )
+  }
   return (
     <SharedEmptyState
       className="rounded-md border"
-      description={
-        isActiveFilter
-          ? 'Du har inga aktiva kontroller just nu.'
-          : 'Inga kontroller matchar det valda filtret.'
-      }
-      action={
-        isActiveFilter && canCreate ? (
-          <Button asChild>
-            <Link href="/laglistor/kontroller/skapa">
-              <Plus className="mr-1.5 h-4 w-4" aria-hidden="true" />
-              Skapa kontroll
-            </Link>
-          </Button>
-        ) : undefined
-      }
+      description="Inga kontroller matchar det valda filtret."
     />
   )
 }

--- a/components/features/document-list/compliance-detail-table.tsx
+++ b/components/features/document-list/compliance-detail-table.tsx
@@ -69,10 +69,7 @@ import {
 import { KravpunkterChecklist } from './legal-document-modal/kravpunkter-checklist'
 import { RichTextDisplay } from '@/components/ui/rich-text-editor'
 import useSWR from 'swr'
-import {
-  getRequirementsForListItem,
-  type RequirementWithEvidence,
-} from '@/app/actions/law-list-item-requirements'
+import { type RequirementWithEvidence } from '@/app/actions/law-list-item-requirements'
 import { BulkActionBar } from './bulk-action-bar'
 import { ComplianceStatusEditor } from './table-cell-editors/compliance-status-editor'
 import { PriorityEditor } from './table-cell-editors/priority-editor'
@@ -511,12 +508,21 @@ function ExpandedRowContent({
 /**
  * Story 17.18: Table cell for the "Kravpunkter" column. Renders either a live
  * `N/M uppfyllda` progress pill (when requirements exist) or a "+ Lägg till"
- * ghost button (when none exist). Uses the SAME SWR cache key as
- * KravpunkterChecklist so mutations in the expansion/modal auto-update the cell
- * and vice versa — one source of truth, no double-fetch on expand.
+ * ghost button (when none exist).
+ *
+ * Counts come pre-batched from the server (`getDocumentListItems` →
+ * `requirementTotal`/`requirementFulfilled`) so the cell renders instantly with
+ * NO per-row fetch — previously every visible row fired its own
+ * `getRequirementsForListItem` server action, producing a 40–50-POST burst on
+ * each page load/refresh. The cell still SUBSCRIBES (no fetcher) to the SAME
+ * SWR key as KravpunkterChecklist, so when the user opens the expansion/modal
+ * the checklist's fetch + optimistic mutations update the pill live. Cache data
+ * (when present) wins over the server-provided initial counts.
  */
 interface KravpunkterCountCellProps {
   listItemId: string
+  initialTotal: number
+  initialFulfilled: number
   isNotApplicable: boolean
   readOnly: boolean
   onAddClick: () => void
@@ -524,33 +530,33 @@ interface KravpunkterCountCellProps {
 
 function KravpunkterCountCell({
   listItemId,
+  initialTotal,
+  initialFulfilled,
   isNotApplicable,
   readOnly,
   onAddClick,
 }: KravpunkterCountCellProps) {
-  // Same key as KravpunkterChecklist — shared SWR cache.
-  const { data: requirements, isLoading } = useSWR<RequirementWithEvidence[]>(
+  // Pure cache subscriber: a null fetcher means this never triggers a request,
+  // it only re-renders when KravpunkterChecklist (which shares this key) loads
+  // or mutates the data. Until then we render the server-batched initial counts.
+  const { data: requirements } = useSWR<RequirementWithEvidence[]>(
     `list-item-requirements:${listItemId}`,
-    async () => {
-      const result = await getRequirementsForListItem(listItemId)
-      if (!result.success || !result.data) {
-        throw new Error(result.error ?? 'Kunde inte hämta kravpunkter')
-      }
-      return result.data
-    },
-    { revalidateOnFocus: false, dedupingInterval: 30000 }
+    null,
+    {
+      revalidateOnMount: false,
+      revalidateIfStale: false,
+      revalidateOnFocus: false,
+    }
   )
 
   if (isNotApplicable) {
     return <span className="text-muted-foreground text-sm">—</span>
   }
 
-  if (isLoading && !requirements) {
-    return <div className="h-5 w-16 rounded-md bg-muted/60 animate-pulse" />
-  }
-
-  const total = requirements?.length ?? 0
-  const fulfilled = requirements?.filter((r) => r.isFulfilled).length ?? 0
+  const total = requirements ? requirements.length : initialTotal
+  const fulfilled = requirements
+    ? requirements.filter((r) => r.isFulfilled).length
+    : initialFulfilled
 
   if (total === 0) {
     if (readOnly) {
@@ -898,6 +904,8 @@ export function ComplianceDetailTable({
           <CellErrorBoundary>
             <KravpunkterCountCell
               listItemId={row.original.id}
+              initialTotal={row.original.requirementTotal}
+              initialFulfilled={row.original.requirementFulfilled}
               isNotApplicable={
                 row.original.complianceStatus === 'EJ_TILLAMPLIG'
               }

--- a/components/features/document-list/document-list-page-content.tsx
+++ b/components/features/document-list/document-list-page-content.tsx
@@ -45,8 +45,10 @@ import {
 import { FilterEmptyState } from './filter-empty-state'
 import { SearchInput } from './search-input'
 import { Button } from '@/components/ui/button'
+import { EmptyState } from '@/components/ui/empty-state'
+import { LawListPrimaryAction } from './law-list-primary-action'
 import { ToolbarItemCount } from '@/components/ui/unified-toolbar'
-import { Settings } from 'lucide-react'
+import { FileText, Settings, Upload } from 'lucide-react'
 // Toolbar redesign
 import { LawListToolbar } from './law-list-toolbar'
 import { ViewMenu } from './view-menu'
@@ -871,6 +873,28 @@ export function DocumentListPageContent({
               searchQuery={searchQuery}
               hasActiveFilters={checkHasActiveFilters(complianceFilters)}
               onClearFilters={clearAllFiltersAndSearch}
+            />
+          ) : activeListId &&
+            total === 0 &&
+            !activeGroupFilter &&
+            !isLoadingItems ? (
+            <EmptyState
+              icon={
+                <EmptyState.Icon>
+                  <FileText className="h-8 w-8 text-muted-foreground" />
+                </EmptyState.Icon>
+              }
+              title="Inga dokument i listan ännu"
+              description="Lägg till relevanta regelverk eller importera en befintlig laglista för att komma igång."
+              action={
+                <div className="flex gap-2">
+                  <LawListPrimaryAction />
+                  <Button variant="outline" onClick={handleOpenImport}>
+                    <Upload className="mr-2 h-4 w-4" />
+                    Importera laglista
+                  </Button>
+                </div>
+              }
             />
           ) : viewMode === 'card' ? (
             <GroupedDocumentList

--- a/components/features/document-list/legal-document-modal/accordion-group-label.tsx
+++ b/components/features/document-list/legal-document-modal/accordion-group-label.tsx
@@ -8,23 +8,20 @@
  * trigger's onClick / aria / data-state, so the chevron and dimming react to
  * the group's open state automatically.
  *
- * `count` shows how many rows live in the group, so a collapsed group still
- * tells you there's hidden content.
+ * Note: the previous `count` chip was removed (2026-05-21) — the counts were
+ * static structural counts (Efterlevnad=3, Referens=1, Uppgifter&filer=2),
+ * not dynamic data, so they trained the eye on noise. If we want to reuse
+ * the slot, prefer a meaningful progress / status indicator over a count.
  */
 
 import { forwardRef, type ComponentPropsWithoutRef } from 'react'
 import { ChevronDown } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
-interface AccordionGroupLabelProps extends ComponentPropsWithoutRef<'button'> {
-  /** Number of rows in the group — rendered as a small count chip. */
-  count?: number
-}
-
 export const AccordionGroupLabel = forwardRef<
   HTMLButtonElement,
-  AccordionGroupLabelProps
->(({ children, count, className, ...props }, ref) => (
+  ComponentPropsWithoutRef<'button'>
+>(({ children, className, ...props }, ref) => (
   <button
     ref={ref}
     type="button"
@@ -38,11 +35,6 @@ export const AccordionGroupLabel = forwardRef<
       {children}
     </span>
     <span className="h-px flex-1 bg-border" aria-hidden="true" />
-    {typeof count === 'number' && (
-      <span className="inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-md bg-muted px-1.5 text-[11px] font-semibold tabular-nums text-muted-foreground">
-        {count}
-      </span>
-    )}
     <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200 group-data-[state=open]/grouplabel:rotate-180" />
   </button>
 ))

--- a/components/features/document-list/legal-document-modal/accordion-group-label.tsx
+++ b/components/features/document-list/legal-document-modal/accordion-group-label.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+/**
+ * Story 6.3 follow-up: Left-panel group header.
+ * Clickable header that chunks the modal's accordions into collapsible groups
+ * (Efterlevnad / Referens / Underlag). Designed to be used as the child of a
+ * <CollapsibleTrigger asChild> — it renders a <button> and forwards the
+ * trigger's onClick / aria / data-state, so the chevron and dimming react to
+ * the group's open state automatically.
+ *
+ * `count` shows how many rows live in the group, so a collapsed group still
+ * tells you there's hidden content.
+ */
+
+import { forwardRef, type ComponentPropsWithoutRef } from 'react'
+import { ChevronDown } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface AccordionGroupLabelProps extends ComponentPropsWithoutRef<'button'> {
+  /** Number of rows in the group — rendered as a small count chip. */
+  count?: number
+}
+
+export const AccordionGroupLabel = forwardRef<
+  HTMLButtonElement,
+  AccordionGroupLabelProps
+>(({ children, count, className, ...props }, ref) => (
+  <button
+    ref={ref}
+    type="button"
+    className={cn(
+      'group/grouplabel flex w-full select-none items-center gap-3 px-1 pb-1 pt-3 text-left',
+      className
+    )}
+    {...props}
+  >
+    <span className="font-safiro text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground transition-colors group-hover/grouplabel:text-foreground group-data-[state=closed]/grouplabel:opacity-70">
+      {children}
+    </span>
+    <span className="h-px flex-1 bg-border" aria-hidden="true" />
+    {typeof count === 'number' && (
+      <span className="inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-md bg-muted px-1.5 text-[11px] font-semibold tabular-nums text-muted-foreground">
+        {count}
+      </span>
+    )}
+    <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200 group-data-[state=open]/grouplabel:rotate-180" />
+  </button>
+))
+AccordionGroupLabel.displayName = 'AccordionGroupLabel'

--- a/components/features/document-list/legal-document-modal/business-context.tsx
+++ b/components/features/document-list/legal-document-modal/business-context.tsx
@@ -130,10 +130,26 @@ export function BusinessContext({
       value="business-context"
       className="border rounded-lg border-border/60"
     >
-      <AccordionTrigger className="px-4 py-3 hover:no-underline hover:bg-muted/50 rounded-t-lg data-[state=closed]:rounded-lg">
-        <div className="flex items-center gap-2 text-base font-semibold text-foreground">
-          <HelpCircle className="h-4 w-4" />
-          <span>Hur påverkar detta oss?</span>
+      <AccordionTrigger className="group/trigger px-4 py-3 hover:no-underline hover:bg-muted/50 rounded-t-lg data-[state=closed]:rounded-lg">
+        <div className="flex items-center gap-2 text-base font-semibold text-foreground flex-1 min-w-0">
+          <HelpCircle className="h-4 w-4 shrink-0" />
+          <span className="shrink-0">Hur påverkar detta oss?</span>
+          {/* Collapsed-state meta: 1-line preview when filled, "Ej ifylld" when empty */}
+          {(() => {
+            const preview = content
+              .replace(/<[^>]*>/g, '')
+              .replace(/\s+/g, ' ')
+              .trim()
+            return preview ? (
+              <span className="ml-auto mr-2 max-w-[22ch] truncate text-xs font-normal text-muted-foreground group-data-[state=open]/trigger:hidden">
+                {preview}
+              </span>
+            ) : (
+              <span className="ml-auto mr-2 shrink-0 text-xs font-normal italic text-muted-foreground/70 group-data-[state=open]/trigger:hidden">
+                Ej ifylld
+              </span>
+            )
+          })()}
         </div>
       </AccordionTrigger>
       <AccordionContent className="px-4 pb-4">

--- a/components/features/document-list/legal-document-modal/compliance-narrative.tsx
+++ b/components/features/document-list/legal-document-modal/compliance-narrative.tsx
@@ -186,11 +186,24 @@ export function ComplianceNarrative({
     >
       <AccordionTrigger
         ref={triggerRef}
-        className="px-4 py-3 hover:no-underline hover:bg-muted/50 rounded-t-lg data-[state=closed]:rounded-lg"
+        className="group/trigger px-4 py-3 hover:no-underline hover:bg-muted/50 rounded-t-lg data-[state=closed]:rounded-lg"
       >
-        <div className="flex items-center gap-2 text-base font-semibold text-foreground flex-1">
-          <BookText className="h-4 w-4" />
-          <span>Hur efterlever vi kraven?</span>
+        <div className="flex items-center gap-2 text-base font-semibold text-foreground flex-1 min-w-0">
+          <BookText className="h-4 w-4 shrink-0" />
+          <span className="shrink-0">Hur efterlever vi kraven?</span>
+          {/* Collapsed-state meta: 1-line preview when filled, "Ej ifylld" when empty */}
+          {hasContent ? (
+            <span className="ml-auto mr-2 max-w-[22ch] truncate text-xs font-normal text-muted-foreground group-data-[state=open]/trigger:hidden">
+              {content
+                .replace(/<[^>]*>/g, '')
+                .replace(/\s+/g, ' ')
+                .trim()}
+            </span>
+          ) : (
+            <span className="ml-auto mr-2 shrink-0 text-xs font-normal italic text-muted-foreground/70 group-data-[state=open]/trigger:hidden">
+              Ej ifylld
+            </span>
+          )}
         </div>
       </AccordionTrigger>
       <AccordionContent className="px-4 pb-4">

--- a/components/features/document-list/legal-document-modal/index.tsx
+++ b/components/features/document-list/legal-document-modal/index.tsx
@@ -235,6 +235,7 @@ export function LegalDocumentModal({
         listItem ? (
           <ModalHeader
             listName={listItem.lawList.name}
+            listId={listItem.lawList.id}
             documentNumber={listItem.legalDocument.documentNumber}
             slug={listItem.legalDocument.slug}
             onClose={onClose}

--- a/components/features/document-list/legal-document-modal/kravpunkter-accordion.tsx
+++ b/components/features/document-list/legal-document-modal/kravpunkter-accordion.tsx
@@ -106,13 +106,13 @@ export function KravpunkterAccordion({
     >
       <AccordionTrigger
         ref={triggerRef}
-        className="px-4 py-3 hover:no-underline hover:bg-muted/50 rounded-t-lg data-[state=closed]:rounded-lg"
+        className="group/trigger px-4 py-3 hover:no-underline hover:bg-muted/50 rounded-t-lg data-[state=closed]:rounded-lg"
       >
         <div className="flex items-center gap-2 text-base font-semibold text-foreground flex-1">
           <ClipboardCheck className="h-4 w-4" />
           <span>Kravpunkter</span>
           {progress.total > 0 && (
-            <div className="flex items-center gap-2 ml-auto mr-2 font-normal">
+            <div className="flex items-center gap-2 ml-auto mr-2 font-normal group-data-[state=open]/trigger:hidden">
               <span className="text-xs text-muted-foreground tabular-nums">
                 {progress.fulfilled}/{progress.total} uppfyllda
               </span>

--- a/components/features/document-list/legal-document-modal/law-header.tsx
+++ b/components/features/document-list/legal-document-modal/law-header.tsx
@@ -10,12 +10,25 @@
  * status/priority colors via `lib/ui/badge-tones.ts`. Dot/icon prefix
  * preserved as inline content; the bg/text class strings now flow from the
  * shared map and adapt to light + dark theme automatically.
+ *
+ * 2026-05-21 — AI-sammanfattning packaging: was previously rendered as a
+ * tall always-visible blue callout under the badge row, dwarfing the
+ * action surface below. Now lives as a default-closed Collapsible: the
+ * trigger is a discreet Sparkles pill in the badge row ("Visa AI-
+ * sammanfattning ▾"); when expanded, the body renders with neutral chrome
+ * (--border, --muted) so it doesn't read as the generic blue "AI card."
  */
 
-import { Flag } from 'lucide-react'
+import { useState } from 'react'
+import { Flag, Sparkles, ChevronDown } from 'lucide-react'
 import type { ReactNode } from 'react'
 import { cn } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
 import {
   getStatusBadgeProps,
   getPriorityBadgeProps,
@@ -53,54 +66,86 @@ export function LawHeader({
     complianceStatus
   )
   const priorityProps = getPriorityBadgeProps(priority)
+  const [summaryOpen, setSummaryOpen] = useState(false)
 
   return (
-    <div className="space-y-3">
-      {/* Title — Safiro Medium for the brand/identity moment (Story 26.x).
-          Safiro ships at weight 500, so use font-medium (font-semibold would
-          trigger faux-bold and ruin the display face). */}
-      <h2 className="font-safiro text-xl font-medium leading-tight tracking-[-0.01em]">
-        {title}
-      </h2>
+    <Collapsible open={summaryOpen} onOpenChange={setSummaryOpen} asChild>
+      <div className="space-y-3">
+        {/* Title — Safiro Medium for the brand/identity moment (Story 26.x).
+            Safiro ships at weight 500, so use font-medium (font-semibold would
+            trigger faux-bold and ruin the display face). */}
+        <h2 className="font-safiro text-xl font-medium leading-tight tracking-[-0.01em]">
+          {title}
+        </h2>
 
-      {/* Status and Priority Badges */}
-      <div className="flex flex-wrap items-center gap-2">
-        <Badge
-          tone={complianceProps.tone}
-          variant={complianceProps.variant}
-          className="gap-1.5"
-        >
-          <span
-            className={cn(
-              'h-2 w-2 rounded-full',
-              DOT_BG_CLASS[complianceProps.tone]
-            )}
-            aria-hidden="true"
-          />
-          {complianceProps.label}
-        </Badge>
+        {/* Status and Priority Badges */}
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge
+            tone={complianceProps.tone}
+            variant={complianceProps.variant}
+            className="gap-1.5"
+          >
+            <span
+              className={cn(
+                'h-2 w-2 rounded-full',
+                DOT_BG_CLASS[complianceProps.tone]
+              )}
+              aria-hidden="true"
+            />
+            {complianceProps.label}
+          </Badge>
 
-        <Badge
-          tone={priorityProps.tone}
-          variant={priorityProps.variant}
-          className="gap-1.5"
-        >
-          <Flag className="h-3 w-3" aria-hidden="true" />
-          {priorityProps.label}
-        </Badge>
+          <Badge
+            tone={priorityProps.tone}
+            variant={priorityProps.variant}
+            className="gap-1.5"
+          >
+            <Flag className="h-3 w-3" aria-hidden="true" />
+            {priorityProps.label}
+          </Badge>
 
-        {headerActions && <div className="ml-auto">{headerActions}</div>}
-      </div>
+          {/* AI-sammanfattning toggle — only rendered when a summary exists.
+              Lives in the badge row so the pill semantics are consistent with
+              its neighbours; default-closed so the modal opens onto the
+              actionable section accordions, not onto a wall of context text. */}
+          {aiCommentary && (
+            <CollapsibleTrigger asChild>
+              <button
+                type="button"
+                className="group inline-flex items-center gap-1.5 rounded-md border border-dashed border-border bg-transparent px-2 py-0.5 text-xs text-muted-foreground transition-colors hover:border-border hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+                aria-label={
+                  summaryOpen
+                    ? 'Dölj AI-sammanfattning'
+                    : 'Visa AI-sammanfattning'
+                }
+              >
+                <Sparkles className="h-3 w-3" aria-hidden="true" />
+                <span>Visa AI-sammanfattning</span>
+                <ChevronDown
+                  className={cn(
+                    'h-3 w-3 transition-transform duration-200',
+                    summaryOpen && 'rotate-180'
+                  )}
+                  aria-hidden="true"
+                />
+              </button>
+            </CollapsibleTrigger>
+          )}
 
-      {/* AI Commentary if present */}
-      {aiCommentary && (
-        <div className="bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
-          <p className="text-sm text-blue-800 dark:text-blue-200">
-            <span className="font-medium">AI-sammanfattning: </span>
-            {aiCommentary}
-          </p>
+          {headerActions && <div className="ml-auto">{headerActions}</div>}
         </div>
-      )}
-    </div>
+
+        {/* Expanded AI-sammanfattning body — neutral chrome (border + muted
+            bg) so the block is visually distinct from regular content without
+            reading as the generic blue "AI card." */}
+        {aiCommentary && (
+          <CollapsibleContent>
+            <div className="rounded-md border border-border bg-muted/40 p-3 text-sm leading-relaxed text-muted-foreground">
+              {aiCommentary}
+            </div>
+          </CollapsibleContent>
+        )}
+      </div>
+    </Collapsible>
   )
 }

--- a/components/features/document-list/legal-document-modal/law-header.tsx
+++ b/components/features/document-list/legal-document-modal/law-header.tsx
@@ -56,8 +56,12 @@ export function LawHeader({
 
   return (
     <div className="space-y-3">
-      {/* Title - aligned with Task Modal (text-xl) */}
-      <h2 className="text-xl font-semibold leading-tight">{title}</h2>
+      {/* Title — Safiro Medium for the brand/identity moment (Story 26.x).
+          Safiro ships at weight 500, so use font-medium (font-semibold would
+          trigger faux-bold and ruin the display face). */}
+      <h2 className="font-safiro text-xl font-medium leading-tight tracking-[-0.01em]">
+        {title}
+      </h2>
 
       {/* Status and Priority Badges */}
       <div className="flex flex-wrap items-center gap-2">

--- a/components/features/document-list/legal-document-modal/left-panel.tsx
+++ b/components/features/document-list/legal-document-modal/left-panel.tsx
@@ -6,9 +6,14 @@
  * Scrollable panel with law header, lagtext, business context, tasks, and activity tabs
  */
 
-import { useState } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { ChevronsDownUp, ChevronsUpDown } from 'lucide-react'
 import { Accordion } from '@/components/ui/accordion'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
 import { Button } from '@/components/ui/button'
 import {
   Tooltip,
@@ -17,6 +22,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { LawHeader } from './law-header'
+import { AccordionGroupLabel } from './accordion-group-label'
 import { LagtextSection } from './lagtext-section'
 import { BusinessContext } from './business-context'
 import { ComplianceNarrative } from './compliance-narrative'
@@ -70,14 +76,14 @@ interface LeftPanelProps {
     | undefined
 }
 
-// Story 21.22: top-down compliance authoring flow:
-// lagtext (the law) → business-context (how it affects us) → compliance-narrative
-// (how we comply) → kravpunkter (specific requirements) → tasks → underlag.
+// Accordion item values. Ordered to mirror the on-screen group order
+// (Efterlevnad → Referens → Underlag); the order here only affects the
+// toggle-all spread — the visual layout/grouping lives in the JSX below.
 const ACCORDION_ITEMS = [
-  'lagtext',
   'business-context',
   'compliance-narrative',
   'kravpunkter',
+  'lagtext',
   'tasks',
   'linked-artifacts',
 ] as const
@@ -102,6 +108,41 @@ const KRAVPUNKTER_FOCUS_OPEN: string[] = ['kravpunkter']
  * point intent takes precedence. Module-scoped ref, no storage.
  */
 let lastSessionOpen: string[] | null = null
+
+/**
+ * Collapsible left-panel groups. Persisted to localStorage so a folded-away
+ * group stays folded across sessions/devices — a durable personal "focus
+ * filter" (e.g. "hide the law text + underlag while I do compliance work").
+ * Global (not per-law) on purpose: the fold is a working mode, not a per-law
+ * setting. `focusField` and the right-panel deep-link shortcuts force the
+ * relevant group open (see below) so content is never silently unreachable.
+ */
+type GroupId = 'efterlevnad' | 'referens' | 'underlag'
+const GROUP_IDS: GroupId[] = ['efterlevnad', 'referens', 'underlag']
+const COLLAPSED_GROUPS_KEY = 'laglig:legal-modal-collapsed-groups'
+
+function loadCollapsedGroups(): GroupId[] {
+  if (typeof window === 'undefined') return []
+  try {
+    const parsed = JSON.parse(
+      window.localStorage.getItem(COLLAPSED_GROUPS_KEY) ?? '[]'
+    )
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((g): g is GroupId =>
+      (GROUP_IDS as string[]).includes(g)
+    )
+  } catch {
+    return []
+  }
+}
+
+function persistCollapsedGroups(groups: GroupId[]): void {
+  try {
+    window.localStorage.setItem(COLLAPSED_GROUPS_KEY, JSON.stringify(groups))
+  } catch {
+    // localStorage unavailable (private mode / quota) — fall back to in-memory
+  }
+}
 
 export function LeftPanel({
   listItem,
@@ -134,7 +175,74 @@ export function LeftPanel({
     setOpenItemsState(next)
   }
   const allOpen = openItems.length === ACCORDION_ITEMS.length
-  const toggleAll = () => setOpenItems(allOpen ? [] : [...ACCORDION_ITEMS])
+
+  // Collapsible group state (localStorage-backed). A group id present here = folded.
+  const [collapsedGroups, setCollapsedGroups] =
+    useState<GroupId[]>(loadCollapsedGroups)
+
+  const toggleGroup = useCallback((id: GroupId) => {
+    setCollapsedGroups((prev) => {
+      const next = prev.includes(id)
+        ? prev.filter((g) => g !== id)
+        : [...prev, id]
+      persistCollapsedGroups(next)
+      return next
+    })
+  }, [])
+
+  const openGroup = useCallback((id: GroupId) => {
+    setCollapsedGroups((prev) => {
+      if (!prev.includes(id)) return prev
+      const next = prev.filter((g) => g !== id)
+      persistCollapsedGroups(next)
+      return next
+    })
+  }, [])
+
+  // Entry-point intent wins: if the modal opens focused on a field, make sure
+  // its group is unfolded (all current focusFields live under "Efterlevnad").
+  useEffect(() => {
+    if (
+      focusField === 'businessContext' ||
+      focusField === 'complianceNarrative' ||
+      focusField === 'kravpunkter'
+    ) {
+      openGroup('efterlevnad')
+    }
+  }, [focusField, openGroup])
+
+  // Right-panel deep-link shortcuts scroll to a row inside a (maybe folded)
+  // group. Unfold the group first, then re-scroll once it has expanded.
+  useEffect(() => {
+    const reveal = (group: GroupId, targetId: string) => {
+      openGroup(group)
+      window.setTimeout(() => {
+        document
+          .getElementById(targetId)
+          ?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+      }, 240)
+    }
+    const onKrav = () => reveal('efterlevnad', 'kravpunkter-accordion')
+    const onArtifacts = () => reveal('underlag', 'linked-artifacts-accordion')
+    window.addEventListener('laglig:focus-kravpunkter', onKrav)
+    window.addEventListener('laglig:focus-linked-artifacts', onArtifacts)
+    return () => {
+      window.removeEventListener('laglig:focus-kravpunkter', onKrav)
+      window.removeEventListener('laglig:focus-linked-artifacts', onArtifacts)
+    }
+  }, [openGroup])
+
+  // "Expand all" reveals everything (rows + any folded groups); "collapse all"
+  // just closes the rows and leaves the group labels in place.
+  const toggleAll = () => {
+    if (allOpen) {
+      setOpenItems([])
+    } else {
+      setOpenItems([...ACCORDION_ITEMS])
+      setCollapsedGroups([])
+      persistCollapsedGroups([])
+    }
+  }
 
   return (
     <div className="p-6 space-y-4 overflow-hidden">
@@ -171,71 +279,113 @@ export function LeftPanel({
         }
       />
 
-      {/* Lagtext, Business Context, and Tasks Accordions */}
-      <Accordion
-        type="multiple"
-        value={openItems}
-        onValueChange={setOpenItems}
-        className="space-y-2"
-      >
-        {/* Lagtext Section */}
-        <LagtextSection
-          documentId={listItem.legalDocument.id}
-          htmlContent={listItem.legalDocument.htmlContent}
-          fullText={null}
-          slug={listItem.legalDocument.slug}
-          sourceUrl={listItem.legalDocument.sourceUrl}
-          isLoading={isLoadingContent || false}
-        />
+      {/*
+        Grouped accordions (Story 6.3 follow-up). Three collapsible groups give
+        the panel hierarchy + a personal focus filter: the user's own compliance
+        work, then the read-only law, then tasks & files. Each group is a
+        <Collapsible> whose trigger is the group label; folded state persists in
+        localStorage (see COLLAPSED_GROUPS_KEY). Items stay inside one Accordion
+        root so its row state/keyboard nav are unaffected. (Group ids stay
+        'efterlevnad'/'referens'/'underlag' internally even though the third
+        label reads "Uppgifter & filer", so saved localStorage state is stable.)
+          Efterlevnad:       business-context → compliance-narrative → kravpunkter
+          Referens:          lagtext (the law itself, read-only reference)
+          Uppgifter & filer: tasks → linked-artifacts
+      */}
+      <Accordion type="multiple" value={openItems} onValueChange={setOpenItems}>
+        <Collapsible
+          open={!collapsedGroups.includes('efterlevnad')}
+          onOpenChange={() => toggleGroup('efterlevnad')}
+          className="mt-1 first:mt-0"
+        >
+          <CollapsibleTrigger asChild>
+            <AccordionGroupLabel count={3}>Efterlevnad</AccordionGroupLabel>
+          </CollapsibleTrigger>
+          <CollapsibleContent className="space-y-2 pt-2">
+            {/* Business Context */}
+            <BusinessContext
+              listItemId={listItem.id}
+              initialContent={listItem.businessContext}
+              onContentChange={onBusinessContextChange}
+              autoEdit={focusField === 'businessContext'}
+            />
 
-        {/* Business Context */}
-        <BusinessContext
-          listItemId={listItem.id}
-          initialContent={listItem.businessContext}
-          onContentChange={onBusinessContextChange}
-          autoEdit={focusField === 'businessContext'}
-        />
+            {/* Story 21.22: Hur efterlever vi kraven? — first-class compliance narrative */}
+            <ComplianceNarrative
+              listItemId={listItem.id}
+              initialContent={listItem.complianceNarrative}
+              updatedAt={listItem.complianceNarrativeUpdatedAt}
+              updatedByName={complianceNarrativeUpdatedByName}
+              onContentChange={onComplianceNarrativeChange}
+              focusField={focusField}
+              readOnly={complianceReadOnly}
+            />
 
-        {/* Story 21.22: Hur efterlever vi kraven? — first-class compliance narrative */}
-        <ComplianceNarrative
-          listItemId={listItem.id}
-          initialContent={listItem.complianceNarrative}
-          updatedAt={listItem.complianceNarrativeUpdatedAt}
-          updatedByName={complianceNarrativeUpdatedByName}
-          onContentChange={onComplianceNarrativeChange}
-          focusField={focusField}
-          readOnly={complianceReadOnly}
-        />
+            {/* Story 17.16 + 21.22: Kravpunkter checklist (no longer bundles a free-text field) */}
+            <KravpunkterAccordion
+              listItemId={listItem.id}
+              focusField={focusField}
+              readOnly={complianceReadOnly}
+              onProgressChange={onKravpunkterProgressChange}
+              workspaceMembers={workspaceMembers}
+              listItemResponsibleUserId={listItemResponsibleUserId ?? null}
+              focusRequirementId={focusRequirementId}
+            />
+          </CollapsibleContent>
+        </Collapsible>
 
-        {/* Story 17.16 + 21.22: Kravpunkter checklist (no longer bundles a free-text field) */}
-        <KravpunkterAccordion
-          listItemId={listItem.id}
-          focusField={focusField}
-          readOnly={complianceReadOnly}
-          onProgressChange={onKravpunkterProgressChange}
-          workspaceMembers={workspaceMembers}
-          listItemResponsibleUserId={listItemResponsibleUserId ?? null}
-          focusRequirementId={focusRequirementId}
-        />
+        <Collapsible
+          open={!collapsedGroups.includes('referens')}
+          onOpenChange={() => toggleGroup('referens')}
+          className="mt-4"
+        >
+          <CollapsibleTrigger asChild>
+            <AccordionGroupLabel count={1}>Referens</AccordionGroupLabel>
+          </CollapsibleTrigger>
+          <CollapsibleContent className="space-y-2 pt-2">
+            {/* Lagtext Section */}
+            <LagtextSection
+              documentId={listItem.legalDocument.id}
+              htmlContent={listItem.legalDocument.htmlContent}
+              fullText={null}
+              slug={listItem.legalDocument.slug}
+              sourceUrl={listItem.legalDocument.sourceUrl}
+              isLoading={isLoadingContent || false}
+            />
+          </CollapsibleContent>
+        </Collapsible>
 
-        {/* Story 6.15: Tasks Accordion */}
-        {onTasksUpdate && (
-          <TasksAccordion
-            taskProgress={taskProgress ?? null}
-            listItemId={listItem.id}
-            onTasksUpdate={onTasksUpdate}
-            onOpenTask={onOpenTask}
-            currentUserId={currentUserId}
-            onOptimisticUpdate={onOptimisticTaskUpdate}
-            columns={taskColumns}
-          />
-        )}
+        <Collapsible
+          open={!collapsedGroups.includes('underlag')}
+          onOpenChange={() => toggleGroup('underlag')}
+          className="mt-4"
+        >
+          <CollapsibleTrigger asChild>
+            <AccordionGroupLabel count={onTasksUpdate ? 2 : 1}>
+              Uppgifter & filer
+            </AccordionGroupLabel>
+          </CollapsibleTrigger>
+          <CollapsibleContent className="space-y-2 pt-2">
+            {/* Story 6.15: Tasks Accordion */}
+            {onTasksUpdate && (
+              <TasksAccordion
+                taskProgress={taskProgress ?? null}
+                listItemId={listItem.id}
+                onTasksUpdate={onTasksUpdate}
+                onOpenTask={onOpenTask}
+                currentUserId={currentUserId}
+                onOptimisticUpdate={onOptimisticTaskUpdate}
+                columns={taskColumns}
+              />
+            )}
 
-        {/* Story 17.18: Consolidated linked artifacts panel */}
-        <LinkedArtifactsPanel
-          entity={{ type: 'list_item', id: listItem.id }}
-          readOnly={complianceReadOnly}
-        />
+            {/* Story 17.18: Consolidated linked artifacts panel */}
+            <LinkedArtifactsPanel
+              entity={{ type: 'list_item', id: listItem.id }}
+              readOnly={complianceReadOnly}
+            />
+          </CollapsibleContent>
+        </Collapsible>
       </Accordion>
 
       {/* Activity Tabs */}

--- a/components/features/document-list/legal-document-modal/left-panel.tsx
+++ b/components/features/document-list/legal-document-modal/left-panel.tsx
@@ -299,7 +299,7 @@ export function LeftPanel({
           className="mt-1 first:mt-0"
         >
           <CollapsibleTrigger asChild>
-            <AccordionGroupLabel count={3}>Efterlevnad</AccordionGroupLabel>
+            <AccordionGroupLabel>Efterlevnad</AccordionGroupLabel>
           </CollapsibleTrigger>
           <CollapsibleContent className="space-y-2 pt-2">
             {/* Business Context */}
@@ -340,7 +340,7 @@ export function LeftPanel({
           className="mt-4"
         >
           <CollapsibleTrigger asChild>
-            <AccordionGroupLabel count={1}>Referens</AccordionGroupLabel>
+            <AccordionGroupLabel>Referens</AccordionGroupLabel>
           </CollapsibleTrigger>
           <CollapsibleContent className="space-y-2 pt-2">
             {/* Lagtext Section */}
@@ -361,9 +361,7 @@ export function LeftPanel({
           className="mt-4"
         >
           <CollapsibleTrigger asChild>
-            <AccordionGroupLabel count={onTasksUpdate ? 2 : 1}>
-              Uppgifter & filer
-            </AccordionGroupLabel>
+            <AccordionGroupLabel>Uppgifter & filer</AccordionGroupLabel>
           </CollapsibleTrigger>
           <CollapsibleContent className="space-y-2 pt-2">
             {/* Story 6.15: Tasks Accordion */}

--- a/components/features/document-list/legal-document-modal/linked-artifacts-panel.tsx
+++ b/components/features/document-list/legal-document-modal/linked-artifacts-panel.tsx
@@ -312,12 +312,12 @@ export function LinkedArtifactsPanel({
         highlighted && 'ring-2 ring-amber-400/70 shadow-lg'
       )}
     >
-      <AccordionTrigger className="px-4 py-3 hover:no-underline hover:bg-muted/50 rounded-t-lg data-[state=closed]:rounded-lg">
+      <AccordionTrigger className="group/trigger px-4 py-3 hover:no-underline hover:bg-muted/50 rounded-t-lg data-[state=closed]:rounded-lg">
         <div className="flex items-center gap-2 text-base font-semibold text-foreground flex-1">
           <Paperclip className="h-4 w-4" />
           <span>Länkade filer & dokument</span>
           {totalCount > 0 && (
-            <span className="ml-auto mr-2 text-xs text-muted-foreground tabular-nums font-normal">
+            <span className="ml-auto mr-2 text-xs text-muted-foreground tabular-nums font-normal group-data-[state=open]/trigger:hidden">
               {totalCount}
             </span>
           )}

--- a/components/features/document-list/legal-document-modal/modal-header.tsx
+++ b/components/features/document-list/legal-document-modal/modal-header.tsx
@@ -5,6 +5,7 @@
  * Breadcrumb navigation, share/actions buttons, and close button
  */
 
+import Link from 'next/link'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import {
@@ -16,7 +17,6 @@ import {
 } from '@/components/ui/dropdown-menu'
 import {
   X,
-  ChevronRight,
   Share2,
   MoreHorizontal,
   ExternalLink,
@@ -29,6 +29,7 @@ import { useSplitPanelModalOptional } from '@/components/shared/split-panel-moda
 
 interface ModalHeaderProps {
   listName: string
+  listId: string
   documentNumber: string
   slug: string
   onClose: () => void
@@ -36,6 +37,7 @@ interface ModalHeaderProps {
 
 export function ModalHeader({
   listName,
+  listId,
   documentNumber,
   slug,
   onClose,
@@ -73,13 +75,18 @@ export function ModalHeader({
 
   return (
     <div className="flex items-center justify-between border-b px-6 py-3 bg-background shrink-0">
-      {/* Breadcrumb */}
-      <nav className="flex items-center gap-1 text-sm min-w-0">
-        <span className="text-muted-foreground truncate max-w-[200px]">
+      {/* Parent link — the laglista this law belongs to. The doc number is NOT
+          repeated here (it already lives in the title's parenthetical and in
+          Detaljer → Dokumentnummer); this is a real "up to the list" link
+          rather than a dead two-step breadcrumb. */}
+      <nav className="flex min-w-0 items-center text-sm" aria-label="Brödsmula">
+        <Link
+          href={`/laglistor/${listId}`}
+          onClick={onClose}
+          className="max-w-[260px] truncate text-muted-foreground transition-colors hover:text-foreground hover:underline"
+        >
           {listName}
-        </span>
-        <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" />
-        <span className="font-medium">{documentNumber}</span>
+        </Link>
       </nav>
 
       {/* Action buttons */}

--- a/components/features/document-list/legal-document-modal/modal-header.tsx
+++ b/components/features/document-list/legal-document-modal/modal-header.tsx
@@ -81,7 +81,7 @@ export function ModalHeader({
           rather than a dead two-step breadcrumb. */}
       <nav className="flex min-w-0 items-center text-sm" aria-label="Brödsmula">
         <Link
-          href={`/laglistor/${listId}`}
+          href={`/laglistor?list=${listId}`}
           onClick={onClose}
           className="max-w-[260px] truncate text-muted-foreground transition-colors hover:text-foreground hover:underline"
         >

--- a/components/features/document-list/legal-document-modal/tasks-accordion.tsx
+++ b/components/features/document-list/legal-document-modal/tasks-accordion.tsx
@@ -323,14 +323,14 @@ export function TasksAccordion({
 
   return (
     <AccordionItem value="tasks" className="border rounded-lg border-border/60">
-      <AccordionTrigger className="px-4 py-3 hover:no-underline hover:bg-muted/50 rounded-t-lg data-[state=closed]:rounded-lg">
+      <AccordionTrigger className="group/trigger px-4 py-3 hover:no-underline hover:bg-muted/50 rounded-t-lg data-[state=closed]:rounded-lg">
         <div className="flex items-center gap-2 text-base font-semibold text-foreground flex-1">
           <ListTodo className="h-4 w-4" />
           <span>Uppgifter</span>
 
           {/* Progress indicator */}
           {totalCount > 0 && (
-            <div className="flex items-center gap-2 ml-auto mr-2 font-normal">
+            <div className="flex items-center gap-2 ml-auto mr-2 font-normal group-data-[state=open]/trigger:hidden">
               <span className="text-xs text-muted-foreground tabular-nums">
                 {totalCount - activeCount}/{totalCount} klara
               </span>

--- a/components/features/documents/document-browser-page.tsx
+++ b/components/features/documents/document-browser-page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { Button } from '@/components/ui/button'
+import { EmptyState } from '@/components/ui/empty-state'
 import { Skeleton } from '@/components/ui/skeleton'
 import {
   AlertDialog,
@@ -278,53 +279,51 @@ export function DocumentBrowserPage() {
           ))}
         </div>
       ) : documents.length === 0 ? (
-        <div className="flex flex-col items-center justify-center py-16 text-center">
-          {activeTab === 'arkiverade' ? (
-            <>
-              <Archive className="h-12 w-12 text-muted-foreground/50 mb-4" />
-              <h2 className="text-lg font-medium mb-1">
-                Inga arkiverade dokument
-              </h2>
-              <p className="text-sm text-muted-foreground">
-                Dokument som arkiveras hamnar här.
-              </p>
-            </>
-          ) : (
-            <>
-              <FileText className="h-12 w-12 text-muted-foreground/50 mb-4" />
-              <h2 className="text-lg font-medium mb-1">
-                {filters.search ||
-                filters.types.length > 0 ||
-                filters.statuses.length > 0
-                  ? 'Inga dokument hittades'
-                  : 'Inga styrdokument ännu'}
-              </h2>
-              <p className="text-sm text-muted-foreground mb-4">
-                {filters.search ||
-                filters.types.length > 0 ||
-                filters.statuses.length > 0
-                  ? 'Ändra dina filter för att hitta dokument.'
-                  : 'Kom igång genom att skapa ett nytt styrdokument eller importera ett befintligt.'}
-              </p>
-              {!(
-                filters.search ||
-                filters.types.length > 0 ||
-                filters.statuses.length > 0
-              ) && (
-                <div className="flex gap-2">
-                  <Button onClick={() => setCreateOpen(true)}>
-                    <FilePlus className="mr-2 h-4 w-4" />
-                    Nytt dokument
-                  </Button>
-                  <Button variant="outline" onClick={() => setImportOpen(true)}>
-                    <Upload className="mr-2 h-4 w-4" />
-                    Importera
-                  </Button>
-                </div>
-              )}
-            </>
-          )}
-        </div>
+        activeTab === 'arkiverade' ? (
+          <EmptyState
+            icon={
+              <EmptyState.Icon>
+                <Archive className="h-8 w-8 text-muted-foreground" />
+              </EmptyState.Icon>
+            }
+            title="Inga arkiverade dokument"
+            description="Dokument som arkiveras hamnar här."
+          />
+        ) : filters.search ||
+          filters.types.length > 0 ||
+          filters.statuses.length > 0 ? (
+          <EmptyState
+            icon={
+              <EmptyState.Icon>
+                <FileText className="h-8 w-8 text-muted-foreground" />
+              </EmptyState.Icon>
+            }
+            title="Inga dokument hittades"
+            description="Ändra dina filter för att hitta dokument."
+          />
+        ) : (
+          <EmptyState
+            icon={
+              <EmptyState.Icon>
+                <FileText className="h-8 w-8 text-muted-foreground" />
+              </EmptyState.Icon>
+            }
+            title="Inga styrdokument ännu"
+            description="Skapa ditt första styrdokument från grunden eller importera en befintlig version."
+            action={
+              <div className="flex gap-2">
+                <Button onClick={() => setCreateOpen(true)}>
+                  <FilePlus className="mr-2 h-4 w-4" />
+                  Nytt dokument
+                </Button>
+                <Button variant="outline" onClick={() => setImportOpen(true)}>
+                  <Upload className="mr-2 h-4 w-4" />
+                  Importera
+                </Button>
+              </div>
+            }
+          />
+        )
       ) : (
         <>
           <DocumentTable

--- a/components/features/tasks/task-workspace/index.tsx
+++ b/components/features/tasks/task-workspace/index.tsx
@@ -399,6 +399,7 @@ export function TaskWorkspace({
         {currentTab === 'lista' && (
           <ListTab
             filteredTasks={filteredTasks}
+            totalTasks={tasks.length}
             columns={columns}
             workspaceMembers={workspaceMembers}
             columnSizing={columnSizing}
@@ -411,6 +412,7 @@ export function TaskWorkspace({
             onTaskClick={handleTaskClick}
             onTaskUpdate={handleTaskUpdate}
             onTasksDelete={handleTasksDelete}
+            onCreateTask={() => setCreateTaskModalOpen(true)}
           />
         )}
         {currentTab === 'kalender' && (

--- a/components/features/tasks/task-workspace/list-tab.tsx
+++ b/components/features/tasks/task-workspace/list-tab.tsx
@@ -48,6 +48,7 @@ import {
   MoreHorizontal,
   MessageSquare,
   ListTodo,
+  Plus,
   Trash2,
   UserPlus,
   Flag,
@@ -129,6 +130,8 @@ const PINNED_COLUMN_IDS = new Set(['select', 'dragHandle', 'type', 'actions'])
 
 interface ListTabProps {
   filteredTasks: TaskWithRelations[]
+  /** Total unfiltered task count — used to distinguish truly-empty from filtered-empty in the empty state. */
+  totalTasks: number
   columns: TaskColumnWithCount[]
   workspaceMembers: WorkspaceMember[]
   // Column state from Zustand store
@@ -143,6 +146,7 @@ interface ListTabProps {
   onTaskClick?: (_taskId: string) => void
   onTaskUpdate: (_taskId: string, _updates: Partial<TaskWithRelations>) => void
   onTasksDelete: (_taskIds: string[]) => void
+  onCreateTask: () => void
 }
 
 // ============================================================================
@@ -151,6 +155,7 @@ interface ListTabProps {
 
 export function ListTab({
   filteredTasks,
+  totalTasks,
   columns: taskColumns,
   workspaceMembers,
   columnSizing,
@@ -163,6 +168,7 @@ export function ListTab({
   onTaskClick,
   onTaskUpdate,
   onTasksDelete,
+  onCreateTask,
 }: ListTabProps) {
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({})
 
@@ -815,8 +821,28 @@ export function ListTab({
     }
   }
 
-  // Empty state
+  // Empty state — distinguish truly-empty (no tasks at all in the workspace)
+  // from filtered-empty (workspace has tasks but current filters return zero).
   if (filteredTasks.length === 0) {
+    if (totalTasks === 0) {
+      return (
+        <EmptyState
+          icon={
+            <EmptyState.Icon>
+              <ListTodo className="h-8 w-8 text-muted-foreground" />
+            </EmptyState.Icon>
+          }
+          title="Inga uppgifter ännu"
+          description="Skapa en uppgift för att börja planera och spåra arbetet med er efterlevnad."
+          action={
+            <Button onClick={onCreateTask}>
+              <Plus className="mr-2 h-4 w-4" />
+              Ny uppgift
+            </Button>
+          }
+        />
+      )
+    }
     return (
       <EmptyState
         icon={

--- a/docs/components/empty-state-spec.md
+++ b/docs/components/empty-state-spec.md
@@ -1,8 +1,8 @@
 # `<EmptyState>` — Component Specification
 
-**Version:** 1.0
-**Last Updated:** 2026-05-04
-**Author:** Sarah (PO) — as-built from Story 22.7 implementation
+**Version:** 1.1
+**Last Updated:** 2026-05-21
+**Author:** Sarah (PO) — as-built from Story 22.7 implementation; extended for the doc-fixing branch empty-state consistency sweep (Slice A, 2026-05-21).
 **File:** `components/ui/empty-state.tsx`
 **Story of origin:** [22.7](../stories/completed/22.7.tasks-tabs-atom-alignment.md)
 
@@ -111,6 +111,14 @@ As of PR #60:
 - `components/features/templates/template-catalog-client.tsx` — three variants (full empty, community placeholder, per-domain empty)
 - `components/features/compliance-audit/cycle-list/cycle-list-table.tsx` — Kontroller list empty (with `className="rounded-md border"`)
 
+Added in the doc-fixing branch consistency sweep (Slice A, 2026-05-21):
+
+- `components/features/documents/document-browser-page.tsx` — Styrdokument (three branches: arkiverade / filtered / truly empty with primary+secondary CTAs)
+- `app/(workspace)/filer/_components/documents-browser.tsx` — Filer ("Inga filer ännu" + Ladda upp / Ny mapp)
+- `components/features/document-list/document-list-page-content.tsx` — Laglistor page-level truly-empty (when a list is selected but contains zero items, no filters) — renders `<LawListPrimaryAction />` + "Importera laglista"
+- `components/features/compliance-audit/cycle-list/cycle-list-table.tsx` — Kontroller "Aktiva" branch upgraded to title + icon + description ("Inga kontroller ännu" + new inspirational copy)
+- `components/features/tasks/task-workspace/list-tab.tsx` — Uppgifter now distinguishes truly-empty (`totalTasks === 0` → "Inga uppgifter ännu" + `+ Ny uppgift` action) from filtered-empty (existing "matchar" copy, no action — Slice B will refine to a dashed-border variant)
+
 ---
 
 ## 6. When NOT to use
@@ -150,3 +158,25 @@ The wrapper's `gap-4 py-12` replaces both the `py-N` and the per-element `mb-N`.
 ## 8. Test surface
 
 No dedicated unit test — presentational. Visual smoke when filtering each migrated surface to zero results.
+
+---
+
+## 9. Copy conventions (Slice A, 2026-05-21)
+
+To stop the variance the audit caught (`Tom mapp` vs `Du har inga X just nu` vs untitled paragraphs), all truly-empty list-page states follow one voice:
+
+| Slot | Convention | Example |
+|---|---|---|
+| Title (truly empty) | `Inga {entity} ännu` | `Inga styrdokument ännu`, `Inga filer ännu`, `Inga uppgifter ännu` |
+| Title (filtered with no matches) | `Inga {entity} matchar` (Slice B will refine) | `Inga uppgifter matchar`, `Inga dokument hittades` |
+| Description | One sentence. Lead with the create verb when there's an action; otherwise describe the state. | `Skapa en uppgift för att börja planera och spåra arbetet med er efterlevnad.` |
+| Primary action | Mirrors the page's toolbar primary verb. | `+ Ny uppgift`, `+ Nytt dokument`, `Ladda upp filer` |
+| Secondary action | If the page's toolbar has two actions, the empty state mirrors both. | `Importera`, `Ny mapp`, `Importera laglista` |
+| Icon | `<EmptyState.Icon>` with a lucide icon matching the entity (`h-8 w-8 text-muted-foreground`). | `<FileText />` for docs, `<FolderOpen />` for folders, `<ListTodo />` for tasks, `<ClipboardCheck />` for kontroller |
+
+Forbidden in new code:
+- State-as-title (`Tom mapp`, `Tomt`)
+- Person-perspective titles (`Du har inga X just nu`)
+- Title-less empty states (just a paragraph)
+
+Slice B (deferred): add a `variant: 'empty' | 'filtered'` prop on `<EmptyState>` for a dashed-border icon + "Rensa filter" recovery action; standardize Laglistor's five table-receiver components (compliance-detail-table, document-list-grid, grouped-*) which currently only fire for filtered-to-zero after the Slice A lift.

--- a/docs/epics/epic-14-compliance-partner-agent.md
+++ b/docs/epics/epic-14-compliance-partner-agent.md
@@ -127,6 +127,16 @@ This transforms Laglig from a passive law registry into an active compliance par
 | **14.26** | Anthropic Prompt Caching v1 — Chat Route | Done |
 | **14.27** | Chat Usage Telemetry (`ChatUsageEvent`) | Done |
 
+### Phase 7: Agent Action Card Extensions (sibling work for Epic 19)
+| # | Story | Status |
+|---|-------|--------|
+| **14.28** | `update_requirement` approval (`UPDATE_REQUIREMENT`) | Planned |
+| **14.29** | `add_task_comment` approval (`ADD_TASK_COMMENT`) | Planned |
+| **14.30** | `transition_document_status` approval (`TRANSITION_DOCUMENT_STATUS`) | Planned |
+| **14.31** | Proposal staleness protection (entity-version re-read guard) | Planned |
+
+These extend the `PendingAgentAction` / `AgentActionCard` pattern (14.22–14.24) with write tools that Epic 19's skills consume. Originally drafted as 14.26–14.29 in the Epic 19 PRD, renumbered to 14.28–14.31 (2026-05-20) after Phase 6 claimed 14.26/14.27. Full descriptions live in [`docs/prd/epic-19-agent-partner-skills-subagents.md`](../prd/epic-19-agent-partner-skills-subagents.md) under "Sibling Work."
+
 ---
 
 ## Phase 1: Data Foundation
@@ -569,6 +579,11 @@ Phase 5 (Agent Approval Cards)
 **Superseded stories (archived 2026-03-01):** The following earlier stories have been fully superseded by Epic 14 and moved to `docs/stories/archived/`:
 - **2.10a** (Design Chunking Experiments), **2.10b** (Execute Experiments), **2.10c** (Implement Chunking Strategy) → Superseded by 14.2 (ContentChunk + three-tier chunking) + 14.3 (228K embeddings + Cohere Rerank v4). The experimental approach was replaced by an informed architectural decision documented in `docs/architecture/chunking-strategy.md`.
 - **3.1** (Setup Vector Database for Chat), **3.2** (Implement RAG Query Pipeline) → Superseded by 14.2 (ContentChunk + HNSW index) + 14.3 (embeddings) + 14.7 (agent tools) + 14.8 (retrieval pipeline) + 14.9 (system prompt). The simple RAG pipeline was redesigned as an agentic architecture with tool-based retrieval.
+
+**Superseded stories (archived 2026-05-20):** Superseded by the newer Epic 17 DMS pipeline and Epic 19 tool taxonomy, moved to `docs/stories/archived/`:
+- **14.6** (File Knowledge Extraction & Embedding) → Superseded by Epic 17 **17.8** (text extraction → `WorkspaceFile.extracted_text`) + **17.9** (chunk & embed workspace documents into `ContentChunk`). Same scope, newer and more specific pipeline that Epic 19 depends on.
+- **14.7d** (File Search & Compliance History Tools) → Superseded by Epic 19 **19.2** (`read_file`), **19.3** (diagnostic tools), **19.4** (entity-read tools). The older tool sketch predates the Epic 19 tool taxonomy.
+- **14.12** (Smart Context Cards — Tool-Backed Responses) → Superseded by Epic 19 **19.12** (proactive hem-chat cards driven by the 19.3 diagnostic tools). The diagnostic-tool-backed approach replaces static prompt rewrites; any still-wanted scope folds into 19.12.
 
 ---
 

--- a/docs/plans/2026-05-20-agent-partner-implementation-sequence.md
+++ b/docs/plans/2026-05-20-agent-partner-implementation-sequence.md
@@ -1,0 +1,149 @@
+# Plan: Agent Partner — Implementation Sequence
+
+**Created:** 2026-05-20
+**Scope:** The full agent-partner vision across Epic 14 (approval cards), Epic 17 (DMS), Epic 19 (skills/subagents/governance), plus the chat-UX-parity story 14.19.
+**Linked docs:** [`docs/stories/EPIC-19-AGENT-PARTNER-CHECKLIST.md`](../stories/EPIC-19-AGENT-PARTNER-CHECKLIST.md), [`docs/prd/epic-19-agent-partner-skills-subagents.md`](../prd/epic-19-agent-partner-skills-subagents.md)
+
+---
+
+## TL;DR
+
+One ordered critical path (Track A) delivers the agent-partner loop. Two independent tracks (B = RAG quality, C = a superseded-pending story) run on their own clocks.
+
+1. **Phase 0:** Draft the four renumbered sibling stories; fix one status note. (No code.)
+2. **Phase 1:** Close the inline-card stack (14.22–24) — mostly built.
+3. **Phase 2:** DMS foundation — 17.8 text extraction is the single biggest blocker.
+4. **Phase 3:** Agent sight + diagnostics (19.1–19.5 + 14.28).
+5. **Phase 4:** Skills system (19.6–19.7 + 14.29/14.30). ← read-and-diagnose loop hits its smoke-test DoD.
+6. **Phase 5:** Authoring (17.10–17.11 + 19.8).
+7. **Phase 6:** Scale + governance (19.9–19.12).
+8. **Phase 7:** Chat-UX parity (14.19) — standalone, scheduled last to avoid a 3-way conflict in `chat-message.tsx`.
+
+**The one rule that prevents pain:** `components/features/ai-chat/chat-message.tsx` is touched by the card stack (14.22–24), the feedback thumbs (19.12), and message branching (14.19). Keep those three strictly **linear** — never two in flight at once. Everything else parallelizes along track boundaries.
+
+Rough total: **~12–14 weeks (1 dev) / ~8–10 weeks (2 devs)**.
+
+---
+
+## Current state (verified 2026-05-20)
+
+**Done / in `completed/`:** 14.7a–c (tools), 14.9 (system prompt), 14.15a/b (agent shell + interactive surfaces), 14.16 (citation grounding), 14.18 (collapsed tool calls), 14.20 (extended thinking), 14.21 (web search), 14.25–27 (chat sidebar, prompt caching, usage telemetry), 17.1/12/13/16/17/18 (DMS data models, linking, browser, kravpunkter, linked artifacts).
+
+**Approved, mostly built:** 14.22, 14.23, 14.24.
+
+**Draft (blocker work):** 17.8, 17.9, 17.10, 17.11.
+
+**Renumbered siblings — undrafted (story files do not exist yet):**
+
+| Sibling story | Old # | **Canonical #** |
+|---|---|---|
+| `update_requirement` approval + diff renderer | 14.26 | **14.28** |
+| `add_task_comment` approval | 14.27 | **14.29** |
+| `transition_document_status` approval | 14.28 | **14.30** |
+| Proposal staleness protection | 14.29 | **14.31** |
+
+*(Renumbered in the checklist on 2026-05-20 because Epic 14 shipped 14.26 = Prompt Caching, 14.27 = Usage Telemetry.)*
+
+**Epic 19 (19.1–19.12):** PRD-defined only; full story docs to be drafted via `*create-story` per phase.
+
+---
+
+## Phase 0 — Housekeeping (½ day, no code)
+
+The numbering rename is **already done** in the checklist. Remaining:
+
+- [ ] Draft the four sibling stories **14.28 / 14.29 / 14.30 / 14.31** via `*create-story` (they're referenced but the files don't exist). They can be drafted just-in-time before the phase that consumes each.
+- [ ] Update **14.17** status note → *"Superseded-pending — concept absorbed by 19.7 `gap_analysis` + 19.12 proactive cards; the sidebar-inline-form mechanism is obsoleted by 14.23. Revisit (archive vs. salvage) after 19.12 ships."* **Do NOT archive yet** — it's the only written spec for the severity-aware multi-step-suggestion UX, and 19.12 may borrow from it.
+
+---
+
+## TRACK A — Agent Partner (the main sequence)
+
+### Phase 1 — Close the inline-card stack (~1–2 wk) — *mostly built*
+
+1. **14.22** AgentActionCard + `CREATE_TASK` pilot
+2. **14.23** Extended types + batch card + write-preview decommission
+3. **14.24** `DRAFT_DOCUMENT` approval (Tiptap preview)
+4. Ship behind `agent_partner_v2`; dogfood internally.
+
+### Phase 2 — DMS foundation (~2–3 wk)
+
+5. **17.8** text extraction (PDF/DOCX/XLSX → `WorkspaceFile.extracted_text`) ← **single biggest blocker; start Day 1**
+6. **17.9** workspace-doc RAG pipeline (`ContentChunk` source `WORKSPACE_DOCUMENT`) — needs 17.8
+7. **14.31** proposal staleness protection — *parallel track*; retrofit onto the Phase-1 cards
+
+### Phase 3 — Agent sight + diagnostics (~3 wk)
+
+8. **19.1** chat attachment upload + Claude content-block conversion — needs 17.8
+9. **19.2** `read_file` unified evidence reader — needs 19.1
+10. **19.5** role-based tool registry filter + `AgentDecisionLog` ← **do early; cheap to add to a few tools now, a refactor across 20+ later**
+11. **19.3** diagnostic tools (`list_bevis_gaps`, `list_unassessed_changes`, `list_overdue`, `list_stale_documents`)
+12. **19.4** entity-read tools (`get_law_list_item`, `get_task`, `list_linked_artifacts`) — *parallel with 19.3*
+13. **14.28** `update_requirement` approval + diff renderer
+
+### Phase 4 — Skills system (~2 wk)
+
+14. **19.6** skill loader + directory convention + `activate_skill`
+15. **19.7** ship `assess_change` (migrate `ASSESSMENT_WORKFLOW` literal) + `gap_analysis`
+16. **14.29** `add_task_comment` approval
+17. **14.30** `transition_document_status` approval (ladder guard; agent cannot APPROVE)
+
+✅ **Read-and-diagnose loop hits its smoke-test DoD here.**
+
+### Phase 5 — Authoring (~2 wk)
+
+18. **17.10** workspace doc tools (search / read / list)
+19. **17.11** `create_document` / `update_document` tools
+20. **19.8** `draft_policy` skill + Swedish template seed — needs 17.11 + 14.24 + 19.6
+
+### Phase 6 — Scale + governance (~2 wk; pick by ROI)
+
+21. **19.9** subagent runner + `LegalReasoner` + `DocumentReader`
+22. **19.10** `ParallelAssessor` + `bulk_assess_changes` — needs 19.7 + 19.9 + 14.23
+23. **19.11** Reminders + scheduling tools + `fire-reminders` / `weekly-pulse` crons
+24. **19.12** `AgentFeedback` thumbs + proactive hem-chat cards
+
+### Phase 7 — Chat-UX parity (standalone, ~3–5 days)
+
+25. **14.19** edit & rerun chat messages with branching — **schedule AFTER 19.12.** It rewrites the message-ordering/render path in `chat-message.tsx`, the same file 14.22–24 and 19.12 touch.
+    - *Escape hatch if users demand it sooner:* land **14.19a** (schema + backfill + server actions — pure backend, zero collision) early; defer **14.19b/c** (the `chat-message.tsx` UI) to here.
+
+---
+
+## TRACK B — RAG quality / data backend (independent; no agent deps)
+
+Run any time; nothing in Track A blocks on these.
+
+- **14.2b** amendment full re-ingestion (~34k docs, canonical prompt) — *believed done via a manual batch run; verify and flip status to Done, else ~$1,400 Batch-API run.*
+- **14.13** retrieval ground-truth labeling + accuracy harness (status: Approved, not done) — do **before** any retrieval-tuning / BM25 decision; it's the measurement tool.
+- **14.16** incremental chunk sync with content hashing (status: Draft) — schedule when the chunk-pipeline cost becomes a real bill.
+
+---
+
+## TRACK C — Superseded-pending
+
+- **14.17** Agent action plans (multi-step suggestions) — **not archived.** Mechanism obsoleted by 14.23; concept absorbed by 19.7 + 19.12. Decide archive-vs-salvage *after* 19.12 ships.
+
+---
+
+## Critical-path callouts
+
+- **17.8 is the single biggest blocker** — it sits at the head of every Epic 19 path. With two devs, start it Day 1 of Phase 2 in parallel with closing Phase 1.
+- **19.5 before 19.3/19.4** — adding the role filter + audit log to a handful of tools is cheap; retrofitting it across the full registry later is not.
+- **Defer 19.9/19.10 subagents** until the single-agent loop is dogfooded — they multiply behavior and are easier to tune once the core flow is stable.
+- **17.10/17.11 stay in Phase 5**, not Phase 2 — they only matter for authoring; pushing them late keeps the DMS-foundation phase narrow.
+
+---
+
+## Definition of Done (full vision)
+
+Mirrors `EPIC-19-AGENT-PARTNER-CHECKLIST.md`:
+
+- [ ] Prerequisites shipped: 17.8, 17.9, 17.10, 17.11, 14.22, 14.23, 14.24
+- [ ] Siblings shipped: 14.28, 14.29, 14.30, 14.31
+- [ ] All 12 Epic 19 stories shipped
+- [ ] `agent_partner_v2` enabled in ≥1 customer workspace ≥2 weeks, no regressions
+- [ ] AUDITOR role verified read-only end-to-end; `AgentDecisionLog` populated for every tool call
+- [ ] Three skills live (`assess_change`, `gap_analysis`, `draft_policy`); three subagents live; two crons live
+- [ ] E2E smoke: fresh workspace → attach DOCX → "är vi GDPR-compliant?" → agent reads attachment, runs `gap_analysis`, proposes 3 tasks + 1 policy draft + 2 evidence links → user accepts → all artifacts visible with `via_agent = true`
+- [ ] (Phase 7) 14.19 branching shipped without regressing the card or thumbs surfaces in `chat-message.tsx`

--- a/docs/prd/epic-19-agent-partner-skills-subagents.md
+++ b/docs/prd/epic-19-agent-partner-skills-subagents.md
@@ -139,20 +139,22 @@ Third subagent `parallel-assessor.ts` — fan-out helper invoked by the `assess_
 New Prisma model `Reminder` (id, workspace_id, subject, trigger_at, kind: DOCUMENT_REVIEW | BEVIS_RECHECK | CUSTOM, entity_id, status: PENDING | FIRED | DISMISSED, created_by, via_agent). Two new scheduling tools: `schedule_review(documentId, cadence)` (sets `WorkspaceDocument.review_date` + Reminder row), `schedule_bevis_recheck(requirementId, cadence)` (Reminder row only). New cron endpoint `app/api/cron/fire-reminders/route.ts` (follows existing `sync-sfs-updates/route.ts` pattern) scans PENDING reminders past `trigger_at` and posts workspace notifications. New cron `app/api/cron/weekly-pulse/route.ts` runs `gap_analysis` skill per workspace weekly via a non-interactive subagent; result posted as a `Notification` row surfaced in hem-chat on next open. **Deps:** 19.7 (gap_analysis skill), 19.9 (subagent runner).
 
 **19.12 — `AgentFeedback` model + thumbs UI + proactive hem-chat cards**
-New Prisma model `AgentFeedback` (turn_id, tool_call_id?, rating: UP | DOWN, comment, created_by, workspace_id, created_at). Thumbs-up/down UI added to assistant messages and tool result rows in `chat-message.tsx`. `components/features/dashboard/hem-chat.tsx` extended: on mount, server component calls the four diagnostic tools from 19.3 and renders "du har N bevisluckor, M obedömda ändringar, P överfallna uppgifter, Q styrdokument att granska" as clickable cards. Each card pre-fills a chat prompt that activates the relevant skill (gap_analysis → full report; assess_change → jump into first unassessed). **Deps:** 19.3, 19.6, 19.7.
+New Prisma model `AgentFeedback` (turn_id, tool_call_id?, rating: UP | DOWN, comment, created_by, workspace_id, created_at). Thumbs-up/down UI added to assistant messages and tool result rows in `chat-message.tsx`. `components/features/dashboard/hem-chat.tsx` extended: on mount, server component calls the four diagnostic tools from 19.3 and renders "du har N bevisluckor, M obedömda ändringar, P överfallna uppgifter, Q styrdokument att granska" as clickable cards. Each card pre-fills a chat prompt that activates the relevant skill (gap_analysis → full report; assess_change → jump into first unassessed). **Supersedes** the archived Story 14.12 (Smart Context Cards) — this story owns the Hem context-card behavior via diagnostic tools rather than static prompt rewrites; any still-wanted scope from 14.12 (e.g. upgrading the existing four 14.11 cards to structured tool-backed output) is folded in here. **Deps:** 19.3, 19.6, 19.7.
 
 ---
 
 ## Sibling Work (Epic 14 additions, tracked separately)
 
-These stories are tactical write-tool additions that slot into Epic 14's `PendingAgentAction` pattern. They don't belong in Epic 19 because they're straightforward extensions of the 14.22–14.24 approval-card system. Listed here for traceability:
+These stories are tactical write-tool additions that slot into Epic 14's `PendingAgentAction` pattern. They don't belong in Epic 19 because they're straightforward extensions of the 14.22–14.24 approval-card system. Listed here for traceability.
 
-- **14.26** — `update_requirement` approval (text / is_fulfilled / comment / bevis_required). Adds `UPDATE_REQUIREMENT` to `PendingAgentActionType`. New renderer `update-requirement-renderer.tsx` with old→new diff.
-- **14.27** — `add_task_comment` approval. Adds `ADD_TASK_COMMENT` type.
-- **14.28** — `transition_document_status` approval (DRAFT→IN_REVIEW→APPROVED→SUPERSEDED→ARCHIVED). Adds `TRANSITION_DOCUMENT_STATUS` type. Server-side guard rejects agent-initiated APPROVED transitions (separation of duties — agent can draft but not approve).
-- **14.29** — Proposal staleness protection. Every `PendingAgentAction` accept path re-reads the target entity, compares a `params.entity_version` snapshot against current `updated_at`, fails with Swedish error ("datan har ändrats sedan förslaget gjordes") + re-propose button if drifted. Retroactively applied to all approval types.
+> **Numbering note (2026-05-20):** These sibling stories were originally drafted as 14.26–14.29, but Epic 14 has since shipped 14.26 (Anthropic Prompt Caching v1) and 14.27 (Chat Usage Telemetry) under its Phase 6. The sibling work is therefore renumbered to **14.28–14.31** and owned in Epic 14's new "Phase 7: Agent Action Card Extensions" section.
 
-These can be drafted and scheduled independently of Epic 19. Recommend scheduling 14.26 and 14.29 alongside 19.7 so `assess_change` skill has the full write-tool palette available.
+- **14.28** — `update_requirement` approval (text / is_fulfilled / comment / bevis_required). Adds `UPDATE_REQUIREMENT` to `PendingAgentActionType`. New renderer `update-requirement-renderer.tsx` with old→new diff.
+- **14.29** — `add_task_comment` approval. Adds `ADD_TASK_COMMENT` type.
+- **14.30** — `transition_document_status` approval (DRAFT→IN_REVIEW→APPROVED→SUPERSEDED→ARCHIVED). Adds `TRANSITION_DOCUMENT_STATUS` type. Server-side guard rejects agent-initiated APPROVED transitions (separation of duties — agent can draft but not approve).
+- **14.31** — Proposal staleness protection. Every `PendingAgentAction` accept path re-reads the target entity, compares a `params.entity_version` snapshot against current `updated_at`, fails with Swedish error ("datan har ändrats sedan förslaget gjordes") + re-propose button if drifted. Retroactively applied to all approval types.
+
+These can be drafted and scheduled independently of Epic 19. Recommend scheduling 14.28 (`update_requirement`) and 14.31 (staleness protection) alongside 19.7 so `assess_change` skill has the full write-tool palette available.
 
 ---
 
@@ -174,7 +176,7 @@ These can be drafted and scheduled independently of Epic 19. Recommend schedulin
 
 **Primary Risk 1 — Hallucinated legal interpretation.** The agent could confidently assert "kravpunkt X is fulfilled by policy Y" when it isn't, the user accepts, and the auditor disagrees. This is the existential failure mode for a compliance product.
 
-- **Mitigation:** `is_fulfilled = true` transitions are always Tier-2 proposals (sibling Story 14.26), never auto-applied. Every legal claim in agent output must carry a structured `[Källa: SFS ...]` citation that the model copies verbatim from tool output, not paraphrases. System prompt guardrails forbid "I believe this covers…" phrasings in favor of "this references §X which requires Y — you may want to verify Z." `LegalReasoner` subagent (19.9) is consulted for any interpretation question with meaningful stakes.
+- **Mitigation:** `is_fulfilled = true` transitions are always Tier-2 proposals (sibling Story 14.28), never auto-applied. Every legal claim in agent output must carry a structured `[Källa: SFS ...]` citation that the model copies verbatim from tool output, not paraphrases. System prompt guardrails forbid "I believe this covers…" phrasings in favor of "this references §X which requires Y — you may want to verify Z." `LegalReasoner` subagent (19.9) is consulted for any interpretation question with meaningful stakes.
 - **Rollback:** All agent writes carry `via_agent = true` and `AgentDecisionLog` rows. Bulk query can list every agent-mediated state change in a workspace and roll them back if systematic issue discovered.
 
 **Primary Risk 2 — Skill procedures go stale.** PROCEDURE.md files encode how to do compliance work well, but Swedish law evolves. If a PROCEDURE.md references a repealed SFS or outdated methodology, the agent follows it anyway.
@@ -202,7 +204,7 @@ These can be drafted and scheduled independently of Epic 19. Recommend schedulin
 ## Definition of Done
 
 - [ ] All 12 stories completed with their ACs met
-- [ ] Sibling Stories 14.26–14.29 completed (coordinated with Epic 14)
+- [ ] Sibling Stories 14.28–14.31 completed (coordinated with Epic 14)
 - [ ] Prisma migrations merged: `AgentDecisionLog`, `Reminder`, `AgentFeedback`, `FileCategory` enum extension, `via_agent` columns on affected tables
 - [ ] Three skills live: `assess_change` (migrated), `gap_analysis` (new), `draft_policy` (new)
 - [ ] Three subagents live: `LegalReasoner`, `DocumentReader`, `ParallelAssessor`

--- a/docs/stories/5.14.user-profile-account-settings.md
+++ b/docs/stories/5.14.user-profile-account-settings.md
@@ -1,0 +1,242 @@
+# Story 5.14: Personal Profile & Account Settings ("Min profil")
+
+## Status
+
+Draft
+
+## Story
+
+**As a** logged-in user,
+**I want** a personal profile area where I can edit my display name, upload or change my avatar, and change my password,
+**so that** I can keep my own account details up to date without an admin and without it being tangled up with workspace-level settings.
+
+## Acceptance Criteria
+
+1. A new **"Min profil"** tab is added to the existing `/settings` page (`SettingsTabs`), visible to **every authenticated user regardless of workspace role** (it is personal, not workspace-scoped — no permission gating). It renders in the app UI font (Google Sans Flex, **not** Safiro).
+2. **Display name:** the tab shows a text input pre-filled with the user's current `User.name`. The user can edit and save it. Validation (Zod): trimmed, required (non-empty), max 100 chars, with Swedish error copy ("Namn krävs", "Max 100 tecken").
+3. **Avatar:** the tab shows the user's current avatar (`User.avatar_url` via `AvatarImage`, falling back to initials). The user can upload a new image (PNG/JPG, max 2 MB — same constraints as the workspace logo) which is stored in Supabase Storage and persisted to `User.avatar_url`. The user can also **remove** their avatar (clears `avatar_url`).
+4. **Email:** the user's email is displayed **read-only** (not editable in this story — email change is explicitly out of scope).
+5. **Password change:** the tab provides a "Byt lösenord" section with three fields — current password, new password, confirm new password. The new password is validated against the existing password rules (`ConfirmPasswordSchema`: min 12 chars, must contain uppercase, lowercase, digit, and special character; new + confirm must match). The current password is verified before the change is applied.
+6. **OAuth-only users:** for users who authenticated via Google (no password set), the password section is hidden (or disabled with an explanatory note "Du loggar in med Google och har inget lösenord att ändra"). The exact detection mechanism is confirmed in the architect review (see Dev Notes — Open Technical Questions).
+7. **Feedback & states:** all save actions show pending states (disabled button + spinner) and success/error toasts in Swedish ("Profil uppdaterad", "Lösenordet har uppdaterats", "Något gick fel"). Reuses the existing `sonner` toast pattern.
+8. **Self-only mutation:** server actions that change name/avatar operate **only on the currently-authenticated user** (resolved from the session via `getWorkspaceContext().userId` or the equivalent session lookup). A user can never edit another user's profile.
+9. **Cross-app reflection:** after a successful name or avatar change, the updated value is reflected in the header user menu and the Team members list. Any NextAuth session-token refresh needed for the header to show the new name/avatar immediately is handled per the architect review (see Dev Notes).
+10. **User-menu link:** the user-menu "Profil" item links to the new tab (`/settings?tab=profile`) instead of the generic `/settings`, so "Profil" and "Inställningar" become meaningfully distinct.
+11. Unit tests cover: tab renders for any role, name validation (required + max length), password-form validation (rules + mismatch), OAuth-only password section hidden, and self-only server-action behavior.
+
+## Scope Clarification
+
+**In Scope (This Story):**
+
+- New "Min profil" tab inside the existing `/settings` tabbed interface.
+- Edit display name (`User.name`).
+- Upload / change / remove avatar (`User.avatar_url`) via Supabase Storage.
+- Change password (current → new) via Supabase Auth, including the OAuth-only no-password case.
+- Read-only email display.
+- User-menu "Profil" deep-link to the tab.
+
+**Out of Scope (Deferred / Future Stories):**
+
+- Changing login email (requires re-verification + uniqueness + Supabase Auth sync) — deferred.
+- GDPR data export / account deletion (was bundled in the original Story 5.7 deferral note — separate story).
+- Per-workspace personal preferences beyond what already exists in the Aviseringar (notifications) tab — already shipped, not duplicated here.
+- Two-factor / session management / connected accounts.
+
+## Tasks / Subtasks
+
+- [ ] **Task 1: Add "Min profil" tab to the settings shell** (AC: 1, 10)
+  - [ ] In `components/features/settings/settings-tabs.tsx`, add a `TabsTrigger value="profile"` (icon: `User` from lucide-react, label "Min profil") and a matching `TabsContent value="profile"`. Place it first (before "Allmänt") or immediately after — confirm ordering in review.
+  - [ ] Do **not** gate it behind any permission — it must render for all roles.
+  - [ ] Thread the current user's data (`name`, `email`, `avatar_url`, and an `hasPassword`/auth-provider flag) from the server component `app/(workspace)/settings/page.tsx` into `SettingsTabs` → the new tab. Add the fetch alongside the existing `Promise.all` (resolve current user via `getWorkspaceContextBypassBillingGates().userId` → `prisma.user.findUnique`).
+  - [ ] Update `components/layout/user-menu.tsx` so the "Profil" `Link` points to `/settings?tab=profile`.
+
+- [ ] **Task 2: Build the profile tab component** (AC: 2, 3, 4, 7)
+  - [ ] Create `components/features/settings/profile-tab.tsx` (client component).
+  - [ ] Name field: `react-hook-form` + Zod, pre-filled, Swedish validation copy. Save button with pending state.
+  - [ ] Avatar block: current avatar preview (`Avatar`/`AvatarImage` + initials fallback), file picker (accept image/png,image/jpeg; client-side 2 MB + type guard), "Ladda upp" + "Ta bort" actions.
+  - [ ] Email displayed read-only (muted input or static row).
+  - [ ] Wire success/error toasts via `sonner`.
+
+- [ ] **Task 3: Profile server actions** (AC: 2, 3, 8)
+  - [ ] Create `app/actions/user-profile.ts` with `'use server'`.
+  - [ ] `updateProfileName(name: string)`: resolve current user from session/context, Zod-validate, `prisma.user.update({ where: { id: userId }, data: { name } })`. Return Swedish success/error result. Invalidate the relevant caches (settings members cache tag `workspace-members`, user cache — see Dev Notes).
+  - [ ] `uploadAvatar(formData)`: validate type/size, upload to Supabase Storage (bucket + path confirmed in architect review), update `User.avatar_url`, return new URL.
+  - [ ] `removeAvatar()`: clear `User.avatar_url` (and best-effort delete the stored object).
+  - [ ] Every action MUST scope to the authenticated user's own `id` only.
+
+- [ ] **Task 4: Password change** (AC: 5, 6, 7)
+  - [ ] Add a "Byt lösenord" sub-section to `profile-tab.tsx` (or a small `password-section.tsx`).
+  - [ ] Reuse `ConfirmPasswordSchema` from `lib/validation/auth` (extend with a `currentPassword` field for this form, or compose a new schema that includes it — keep the rule set identical).
+  - [ ] Verify the current password before changing: call `supabase.auth.signInWithPassword({ email, password: currentPassword })` (client) to confirm, then `supabase.auth.updateUser({ password: newPassword })` — mirror the pattern in `app/(auth)/reset-password/confirm/_confirm-password-form.tsx`. (Confirm this re-auth approach in architect review.)
+  - [ ] For OAuth-only users, hide/disable the section per AC 6 using the auth-provider flag from Task 1.
+  - [ ] Success → toast "Lösenordet har uppdaterats"; clear the fields. Error → surface Supabase message.
+
+- [ ] **Task 5: Cross-app reflection** (AC: 9)
+  - [ ] Server action: `revalidateTag('workspace-members')` + `revalidatePath('/settings')` and `invalidateAllUserCache(userId)` so the Team list + cached user row refresh (Architect Decision #4).
+  - [ ] Header refresh (Architect Decision #3): extend `authOptions` callbacks in `app/api/auth/[...nextauth]/route.ts` — `jwt` to handle `trigger === 'update'` (re-read `name` + `avatar_url` from Prisma) and seed `token.picture` on sign-in; `session` to set `session.user.image = token.picture`. After save, call `useSession().update()` on the client. This is the only change to a shared auth file — keep it minimal and additive.
+
+- [ ] **Task 6: Tests** (AC: 11)
+  - [ ] `tests/unit/components/features/settings/profile-tab.test.tsx`: renders for a non-owner role; name required + max-length; password rules + mismatch; password section hidden for OAuth-only user.
+  - [ ] `tests/integration/actions/user-profile.test.ts`: `updateProfileName` updates only the caller's user; rejects invalid name.
+
+## Dev Notes
+
+### Why this story exists / provenance
+
+The personal account settings surface was explicitly deferred when the workspace settings page shipped:
+
+> "User account settings tab (Story TBD - personal profile, password, avatar, GDPR data export/deletion)"
+> — `docs/stories/completed/5.7.workspace-settings-page.md` (Scope Clarification → Deferred to Future Stories)
+
+This story implements the **personal profile + password** slice of that deferral. GDPR export/deletion and email change are left as separate future stories.
+
+### Data model — NO MIGRATION REQUIRED for core scope
+
+The `User` model already has every field this story writes to (`prisma/schema.prisma`):
+
+```prisma
+model User {
+  id             String    @id @default(uuid())
+  email          String    @unique
+  name           String?
+  avatar_url     String?
+  password_hash  String?  // NULL for OAuth users (future), Supabase Auth manages passwords
+  email_verified Boolean   @default(false)
+  ...
+}
+```
+
+- `name` and `avatar_url` are written by the new server actions.
+- `password_hash` is **not** used directly — Supabase Auth owns password state. Treat the comment on the column as authoritative.
+- **Conclusion: this story requires no Prisma schema change / no `prisma migrate`.** (Architect to confirm; a Supabase **Storage bucket / RLS policy** may need provisioning — that's infra, not a Prisma migration. See Open Technical Questions.)
+
+### Existing settings architecture (reuse, don't reinvent)
+
+- Server component: `app/(workspace)/settings/page.tsx` — fetches workspace/members/columns/companyProfile in a `Promise.all`, uses `getWorkspaceContextBypassBillingGates()`. Add the current-user fetch here.
+- Tab shell: `components/features/settings/settings-tabs.tsx` — URL-synced tabs via `?tab=`, `value`/`onValueChange` already wired (`handleTabChange`). Add the new trigger + content; the `initialTab` prop already supports deep-linking, so `/settings?tab=profile` works automatically.
+- Pattern reference for a tab with a form + upload + server action + toasts: the **General tab** (`general-tab.tsx`) and `app/actions/workspace-settings.ts` (`updateWorkspaceName`, `uploadWorkspaceLogo`). Model the new actions on these.
+
+### Auth / password mechanics (verified)
+
+- The app uses **Supabase Auth** for credentials, bridged to **NextAuth** (see `docs/auth-migration-brief.md`; tactical OAuth path per memory). Password changes go through the **client** Supabase SDK on the active session, exactly as in `app/(auth)/reset-password/confirm/_confirm-password-form.tsx`:
+
+  ```ts
+  const { error } = await supabase.auth.updateUser({ password: newPassword })
+  ```
+
+- `supabase.auth.updateUser({ password })` updates the password for the **currently-authenticated session** and does **not** require the old password. To honor the "current → new" UX (AC 5), verify the current password first via `supabase.auth.signInWithPassword({ email, password: currentPassword })` and only proceed on success.
+- Password validation rules already exist: `ConfirmPasswordSchema` in `lib/validation/auth` (min 12; upper/lower/digit/special; confirm match). Reuse them so rules stay consistent with signup + reset.
+
+### Resolving the current user in server actions
+
+`getWorkspaceContext()` (`lib/auth/workspace-context.ts`) returns `{ userId, ... }`. Use `userId` to scope `prisma.user.update`. Every authenticated user has a workspace (Epic 10 guarantee), so this is a safe way to get the user id; alternatively `getServerSession()` → lookup by `email`. The mutation is **personal**, so it needs **no workspace permission check** — but it MUST hard-scope writes to `userId` so a user can only edit themselves (AC 8).
+
+### Avatar upload pattern
+
+The workspace logo uploads to Supabase Storage bucket `workspace-files` at path `${workspaceId}/logo/...` (see `app/actions/workspace-settings.ts` / Story 5.7 Dev Notes). For user avatars, an analogous approach is a per-user path (e.g. `users/${userId}/avatar/...`). Bucket choice + RLS is an architect decision (see Open Technical Questions).
+
+### Swedish copy reference
+
+| English | Swedish |
+| --- | --- |
+| My profile | Min profil |
+| Name | Namn |
+| Avatar / profile picture | Profilbild |
+| Upload | Ladda upp |
+| Remove | Ta bort |
+| Email | E-post |
+| Change password | Byt lösenord |
+| Current password | Nuvarande lösenord |
+| New password | Nytt lösenord |
+| Confirm new password | Bekräfta nytt lösenord |
+| Update password | Uppdatera lösenord |
+| Save changes | Spara ändringar |
+| Profile updated | Profil uppdaterad |
+| Password updated | Lösenordet har uppdaterats |
+| Something went wrong | Något gick fel |
+
+### Architect Review — Resolved Decisions (Winston, 2026-05-21)
+
+The five open questions from the PO draft are resolved below. Each is now a decision the dev must follow, not an open choice.
+
+1. **Avatar storage — dedicated PUBLIC `avatars` bucket, server-side upload via the service-role helper.**
+   - Create a new Supabase Storage bucket named **`avatars`**: `public: true`, `fileSizeLimit: 2 MB`, `allowedMimeTypes: ['image/png','image/jpeg']`. (Public is correct here — avatars are non-sensitive and rendered everywhere; a public bucket yields a stable `getPublicUrl` we persist directly to `User.avatar_url` with no signed-URL refresh treadmill.)
+   - **Do NOT** follow `uploadWorkspaceLogo` in `app/actions/workspace-settings.ts` — it is a **stub** that writes a fake `/api/workspace/.../logo` URL and never uploads. The real pattern is `lib/supabase/storage.ts` (`getStorageClient()` = service-role admin client, `.from(bucket).upload(path, buffer, { contentType, upsert: true })`, `getPublicUrl`).
+   - Upload happens **in the server action** (`uploadAvatar` in `app/actions/user-profile.ts`) using `getStorageClient()`. Path: **`${userId}/avatar-${Date.now()}.<ext>`** (timestamp suffix busts CDN/browser image caching after a re-upload; `removeAvatar` should delete the prior object best-effort). Server-side service-role upload bypasses RLS, so no per-user RLS policy is required for the write path; the bucket being public covers reads.
+
+2. **OAuth-only password detection — Supabase identities are the source of truth, NOT `password_hash`.**
+   - `User.password_hash` is unreliable (Supabase Auth owns passwords; the column is effectively always NULL). Do not branch on it.
+   - In the settings server component, fetch the user's auth identities via the admin client: `getStorageClient()`-style service-role client → `supabase.auth.admin.getUserById(userId)` and inspect `data.user.identities` (or `app_metadata.providers`). Compute `hasPasswordIdentity = identities.some(i => i.provider === 'email')` and pass it to the tab. Hide/disable the password section when `false` (AC 6). (Google-only signups have just a `google` identity.)
+
+3. **Header reflection (AC 9) requires extending the NextAuth callbacks — this is the one shared-file change.**
+   - Verified: `authOptions` (`app/api/auth/[...nextauth]/route.ts`) `jwt`/`session` callbacks carry only `id`, `email`, `name`. **There is no `image` in the token at all** — so the header `UserMenu` `user.image` is always `undefined` today and only ever shows initials. And `name` is written **once** at login (the `jwt` callback only copies from `user` on initial sign-in); it is never re-read.
+   - **Minimal change to satisfy AC 9 for the header:**
+     - Extend the `jwt` callback to (a) accept `trigger === 'update'` and re-read `name` + `avatar_url` from Prisma into the token, and (b) seed `token.picture = avatar_url` on initial sign-in.
+     - Extend the `session` callback to set `session.user.image = token.picture`.
+     - After a successful name/avatar save on the client, call `useSession().update()` to trigger the `jwt` `update` branch so the header refreshes **without re-login**.
+   - **The Team list reflects changes for free** — `getWorkspaceMembers` already `select`s `user.name` + `user.avatar_url` from Prisma; it just needs the cache busted (see #4). If extending the auth callbacks is judged too invasive for "simple", the acceptable fallback is: Team list updates immediately; header updates on next login. Flag this trade-off at implementation; do not silently drop the header refresh.
+
+4. **Cache invalidation on name/avatar change:**
+   - The settings members list is wrapped in `unstable_cache` with tags `workspace-members` + `workspace-${workspaceId}` (see `app/(workspace)/settings/page.tsx`). In the server action call `revalidateTag('workspace-members')` (+ the workspace tag) and `revalidatePath('/settings')`.
+   - Defensively call `invalidateAllUserCache(userId)` from `lib/cache/user-cache.ts` (its `user:session:*` entry caches the full `User` row incl. name/avatar). Redis auth-context (`auth:context:*`) holds role/workspace only — not name/avatar — so it does not need busting for this story.
+
+5. **Current-password verification is safe AND solves the "no Supabase browser session" gotcha.**
+   - Gotcha: app login goes through **NextAuth** (server-side `signInWithPassword` on a non-persisting client) or the OAuth bridge (`exchangeCodeForSession` server-side). Neither reliably leaves a **Supabase browser session**, so a bare `supabase.auth.updateUser({ password })` from the client could fail with "Auth session missing".
+   - Resolution: do the two calls in sequence on the **browser** client (`lib/supabase/client.ts`): `await supabase.auth.signInWithPassword({ email, password: currentPassword })` — this both *verifies* the current password AND *establishes* a fresh Supabase browser session — then `await supabase.auth.updateUser({ password: newPassword })` on that session. This mirrors `reset-password/confirm/_confirm-password-form.tsx` and disturbs **only** the Supabase browser session (same user); the NextAuth cookie (the real app session) is untouched.
+   - Fallback if any session friction appears: do it server-side with `supabase.auth.admin.updateUserById(userId, { password })` after a separate `signInWithPassword` verify — bypasses browser session entirely but needs the service-role key in the action.
+
+### Manual Provisioning / Migrations (run by the user, per environment)
+
+- **Prisma migration: NONE.** `User.name` and `User.avatar_url` already exist — no `prisma migrate` for this story. (Confirmed against `prisma/schema.prisma`.)
+- **Supabase Storage bucket: REQUIRED — one-time, per Supabase project.** Create the `avatars` bucket in **both** Supabase environments (Preview/dev **and** Production — see the Stripe-style env split). A ready-to-run idempotent script is provided at **`scripts/setup-avatars-bucket.ts`**:
+
+  ```bash
+  pnpm tsx scripts/setup-avatars-bucket.ts
+  ```
+
+  Run it once against each environment (it reads `NEXT_PUBLIC_SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` from `.env.local`; point those at each project in turn, or run in each deployment's env). The script is a no-op if the bucket already exists.
+
+## Testing
+
+### Test file locations
+
+- `tests/unit/components/features/settings/profile-tab.test.tsx`
+- `tests/integration/actions/user-profile.test.ts`
+
+### Standards & frameworks
+
+- **Unit/component:** Vitest + React Testing Library (`@testing-library/react`).
+- **Mocking:** `vi.mock` for `useWorkspace`, the Supabase client, and `next/navigation` — mirror the mocking style in the existing `tests/unit/components/features/settings/*.test.tsx` (e.g. `settings-tabs.test.tsx`, `general-tab.test.tsx`).
+- **Coverage focus:** validation logic (name + password), permission-free rendering for all roles, OAuth-only branch, and self-only mutation in the server action.
+
+## Change Log
+
+| Date | Version | Description | Author |
+| --- | --- | --- | --- |
+| 2026-05-21 | 0.1 | Initial draft created from Story 5.7 deferral note; scope confirmed with user: name + avatar + password, as a new "Min profil" tab in `/settings` | Sarah (PO) |
+| 2026-05-21 | 0.2 | Template-alignment pass: added Dev Agent Record + QA Results placeholder sections; ran story-draft-checklist (READY) | Bob (SM) |
+| 2026-05-21 | 0.3 | Architect review: resolved all 5 open technical questions (avatars bucket, OAuth detection via Supabase identities, NextAuth callback extension for header refresh, cache invalidation, current-password re-auth flow); added Manual Provisioning section (no Prisma migration; `avatars` bucket required); concretised Task 5; `scripts/setup-avatars-bucket.ts` provided | Winston (Architect) |
+
+## Dev Agent Record
+
+_This section is populated by the development agent during implementation._
+
+### Agent Model Used
+
+_TBD_
+
+### Debug Log References
+
+_TBD_
+
+### Completion Notes List
+
+_TBD_
+
+### File List
+
+_TBD_
+
+## QA Results
+
+_Results from QA Agent review of the completed story implementation will be recorded here._

--- a/docs/stories/EPIC-19-AGENT-PARTNER-CHECKLIST.md
+++ b/docs/stories/EPIC-19-AGENT-PARTNER-CHECKLIST.md
@@ -38,13 +38,15 @@
 
 ## 🔌 Sibling write-tool additions to Epic 14 (new — coordinated with Epic 19)
 
-- [ ] **14.26** — `update_requirement` approval
+> **Numbering note (2026-05-20):** renumbered from 14.26–14.29 to **14.28–14.31** because Epic 14 shipped 14.26 (Anthropic Prompt Caching v1) and 14.27 (Chat Usage Telemetry) under its Phase 6. These are owned in Epic 14's "Phase 7: Agent Action Card Extensions" section.
+
+- [ ] **14.28** — `update_requirement` approval
   *text / is_fulfilled / comment / bevis_required; new `UPDATE_REQUIREMENT` action type + diff renderer*
-- [ ] **14.27** — `add_task_comment` approval
+- [ ] **14.29** — `add_task_comment` approval
   *New `ADD_TASK_COMMENT` action type*
-- [ ] **14.28** — `transition_document_status` approval
+- [ ] **14.30** — `transition_document_status` approval
   *Ladder guard DRAFT→IN_REVIEW→APPROVED→SUPERSEDED→ARCHIVED; agent cannot APPROVE (separation of duties)*
-- [ ] **14.29** — Proposal staleness protection
+- [ ] **14.31** — Proposal staleness protection
   *entity_version snapshot + re-read check + Swedish error toast; retrofit across all approval types*
 
 ---
@@ -97,7 +99,7 @@
 | Bucket | Count | Gate |
 |---|---|---|
 | Prerequisites (Epic 14 + 17) | 7 | Must ship first or in parallel — blocks most of 19 |
-| Sibling Epic 14 additions | 4 | Schedule 14.26 + 14.29 alongside 19.7 |
+| Sibling Epic 14 additions | 4 | Schedule 14.28 + 14.31 alongside 19.7 |
 | Epic 19 | 12 | Foundation track (19.1–19.5) unblocks all other tracks |
 | **Total** | **23 stories** | ~8–10 weeks with 2 devs |
 
@@ -108,7 +110,7 @@
 ### Shortest route to a usable "agent that does work" (10 stories, ~5 weeks)
 
 ```
-17.8 → 17.9 → 14.22 → 19.1 → 19.2 → 19.5 → 19.6 → 19.7 → 14.26 → 19.3
+17.8 → 17.9 → 14.22 → 19.1 → 19.2 → 19.5 → 19.6 → 19.7 → 14.28 → 19.3
 ```
 
 After this sequence, the core loop is live: agent reads attachments + bevis, diagnoses gaps, proposes fixes via approval cards, runs skills per context. Every remaining story adds capability but the product value is established.
@@ -144,7 +146,7 @@ Agent drafts styrdokument from templates, user reviews in Tiptap preview, approv
 ## 🔒 Definition of Done for the full vision
 
 - [ ] All 7 prerequisite stories shipped (17.8, 17.9, 17.10, 17.11, 14.22, 14.23, 14.24)
-- [ ] All 4 sibling stories shipped (14.26, 14.27, 14.28, 14.29)
+- [ ] All 4 sibling stories shipped (14.28, 14.29, 14.30, 14.31)
 - [ ] All 12 Epic 19 stories shipped
 - [ ] Composite feature flag `agent_partner_v2` enabled in ≥1 customer workspace for ≥2 weeks with no regressions
 - [ ] AUDITOR role verified read-only end-to-end

--- a/docs/stories/archived/14.12.smart-context-cards.md
+++ b/docs/stories/archived/14.12.smart-context-cards.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft
+Archived (2026-05-20) — Superseded by Epic 19 Story **19.12** (`AgentFeedback` + proactive hem-chat cards), which drives the Hem context cards off the 19.3 diagnostic tools (`list_bevis_gaps`, `list_unassessed_changes`, `list_overdue`, `list_stale_documents`) rather than re-writing static card prompts. The diagnostic-tool-backed approach is the durable design; shipping the prompt-rewrite work here separately would duplicate the "Förfallna"/overdue card behavior across two stories. Fold any still-wanted scope into 19.12 — do not implement this story standalone.
 
 ## Story
 

--- a/docs/stories/archived/14.6.file-knowledge-extraction-embedding.md
+++ b/docs/stories/archived/14.6.file-knowledge-extraction-embedding.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft
+Archived (2026-05-20) — Superseded by Epic 17 Stories **17.8** (text extraction pipeline → `WorkspaceFile.extracted_text`) + **17.9** (chunk & embed workspace documents into `ContentChunk` with `WORKSPACE_DOCUMENT` source). The newer DMS-side plan covers the same extraction + embedding scope with a more specific pipeline and is the version Epic 19 depends on. Do not implement this story — see 17.8 / 17.9.
 
 ## Story
 

--- a/docs/stories/archived/14.7d.file-search-compliance-history-tools.md
+++ b/docs/stories/archived/14.7d.file-search-compliance-history-tools.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft
+Archived (2026-05-20) — Superseded by Epic 19 Stories **19.2** (`read_file` unified evidence reader, replacing the `search_user_files` concept), **19.3** (diagnostic tools incl. compliance-history surfacing), and **19.4** (entity-read tools: `get_law_list_item`, `get_task`, `list_linked_artifacts`). The 14.7d tool sketch predates the Epic 19 tool taxonomy; its scope is fully covered there. Do not implement this story — see 19.2 / 19.3 / 19.4.
 
 ## Story
 

--- a/docs/stories/backlog/frontend/22.11.safiro-structure-identity-typography-sweep.md
+++ b/docs/stories/backlog/frontend/22.11.safiro-structure-identity-typography-sweep.md
@@ -54,6 +54,7 @@ The legal-document modal now uses Safiro for its title + group labels under a de
   - [ ] `components/ui/page-header.tsx` + consumers
   - [ ] Modal/drawer headers: task modal, cycle-item modal, manage-list modal, other split-panel-modal consumers
   - [ ] Uppercase labels: e.g. `grep -rn "uppercase" components | grep -iE "text-\[1[01]px\]|text-xs"` to surface eyebrows/section labels
+  - [ ] **Empty-state titles** (`components/ui/empty-state.tsx` + the call sites listed in `docs/components/empty-state-spec.md` §5) — ambiguous under this story's rule (sentence-case section-level headings inside a page body). Slice A of the empty-state consistency sweep (doc-fixing branch, 2026-05-21) deliberately left them on Google Sans Flex per the "when ambiguous, leave it" clause; revisit here to make an explicit apply/leave decision rather than letting it drift.
 - [ ] **Task 3: Apply Safiro to titles** (AC: 3, 4, 7)
 - [ ] **Task 4: Apply Safiro to section/group/eyebrow labels** (AC: 5, 7) — preserve tracking
 - [ ] **Task 5: Legibility QA** at small sizes, light + dark, incl. non-retina/Windows (AC: 8)

--- a/docs/stories/backlog/frontend/22.11.safiro-structure-identity-typography-sweep.md
+++ b/docs/stories/backlog/frontend/22.11.safiro-structure-identity-typography-sweep.md
@@ -1,0 +1,75 @@
+# Story 22.11: Safiro Structure/Identity Typography Sweep
+
+## Status
+
+Draft
+
+## Story
+
+**As a** user of Laglig,
+**I want** the brand display face (Safiro) applied consistently to the app's structural/identity typography — page/view/modal titles and uppercase section/group labels —
+**so that** the product reads as cohesively premium instead of Safiro showing up on one modal as a one-off.
+
+## Story Context
+
+**Existing System Integration:**
+
+- **Precedent (already shipped, this is the follow-up):** `components/features/document-list/legal-document-modal/law-header.tsx` (modal title → `font-safiro` + `font-medium`) and `components/features/document-list/legal-document-modal/accordion-group-label.tsx` (group labels → `font-safiro` + `font-medium`, uppercase tracking preserved).
+- **Utility:** `.font-safiro` in `app/globals.css` — swaps `font-family` only (with `!important`); Safiro ships **weight 500 only**.
+- **Likely surfaces to audit:** `components/ui/page-header.tsx` (PageHeader primitive — page/view titles) and its consumers; other modal/drawer headers (`components/features/tasks/*` task modal, `components/features/compliance-audit/cycle-item-modal/*`, `components/features/document-list/manage-list-modal.tsx`, other `components/shared/split-panel-modal` consumers); uppercase eyebrow/section labels across settings, krav, laglistor, mallar, activity.
+- **Design-system note:** `.claude/skills/frontend-design/SKILL.md` currently reserves Safiro for "display headings / hero / premium moments" — to be updated to the structure/identity rule below.
+- **Technology:** Tailwind + `.font-safiro` utility; Google Sans Flex (`font-sans`) stays the content face.
+
+**Motivation:**
+
+The legal-document modal now uses Safiro for its title + group labels under a deliberate rule: **Safiro = the structural/identity layer (titles + section/group/eyebrow labels); Google Sans Flex = the working content (section titles, body, controls, inputs, badges).** This reads as a stronger, more intentional brand system than a lone Safiro title — the eye learns "Safiro = scaffolding, GSF = content." To stop the modal being a one-off, the rule should be codified and rolled out to equivalent surfaces.
+
+## Acceptance Criteria
+
+**Rule & documentation:**
+
+1. The typography rule is documented and `.claude/skills/frontend-design/SKILL.md` is updated from "Safiro = display/hero only" to: *Safiro = structural/identity type (page/view/modal/drawer titles + uppercase section/group/eyebrow labels); Google Sans Flex = working content.*
+
+**Inventory:**
+
+2. An inventory checklist is produced (in this story's Dev Agent Record) of every surface considered, grouped into (a) titles and (b) uppercase section/group/eyebrow labels. Each entry records: file path + current treatment + decision (apply / leave + reason).
+
+**Apply consistently:**
+
+3. Page/view titles rendered via the `PageHeader` primitive use Safiro (`font-medium`).
+4. Other modal/drawer titles (task modal, cycle-item modal, manage-list modal, etc.) use Safiro (`font-medium`), matching the legal-document-modal precedent.
+5. Uppercase section/group/eyebrow labels on audited surfaces use Safiro while **preserving their existing uppercase letter-spacing**.
+6. Content typography is unchanged: accordion/section titles (e.g. "Hur påverkar detta oss?"), body, form controls, inputs, table cells, and badges stay in Google Sans Flex.
+
+**Quality:**
+
+7. Weight: only `font-medium` (500) on Safiro elements — never `font-semibold`/`font-bold` (Safiro has no bold weight; faux-bold synthesis degrades the face and is forbidden).
+8. Legibility: Safiro applied at small sizes (≤12px uppercase) is verified crisp on Windows / non-retina; where it muddies, bump to ≥12px or add tracking rather than abandoning — record any size floor in the design note.
+9. No regressions: existing layout/spacing unchanged; verified in light + dark; `pnpm typecheck`, `pnpm lint`, and `pnpm test` pass.
+
+## Tasks / Subtasks
+
+- [ ] **Task 1: Codify the rule** (AC: 1) — update `.claude/skills/frontend-design/SKILL.md`; add a short typography note to the design-system docs.
+- [ ] **Task 2: Inventory surfaces** (AC: 2)
+  - [ ] `components/ui/page-header.tsx` + consumers
+  - [ ] Modal/drawer headers: task modal, cycle-item modal, manage-list modal, other split-panel-modal consumers
+  - [ ] Uppercase labels: e.g. `grep -rn "uppercase" components | grep -iE "text-\[1[01]px\]|text-xs"` to surface eyebrows/section labels
+- [ ] **Task 3: Apply Safiro to titles** (AC: 3, 4, 7)
+- [ ] **Task 4: Apply Safiro to section/group/eyebrow labels** (AC: 5, 7) — preserve tracking
+- [ ] **Task 5: Legibility QA** at small sizes, light + dark, incl. non-retina/Windows (AC: 8)
+- [ ] **Task 6: Regression check** — typecheck/lint/tests + visual spot-check of key pages (AC: 9)
+
+## Dev Notes
+
+- **Copy the precedent exactly:**
+  - Title: `font-safiro text-xl font-medium leading-tight tracking-[-0.01em]` (see `law-header.tsx`)
+  - Uppercase label: `font-safiro text-[11px] font-medium uppercase tracking-[0.08em] …` (see `accordion-group-label.tsx`)
+- **`.font-safiro` sets `font-family` only** — it does NOT set weight or letter-spacing. So always set `font-medium` explicitly and keep each element's own `tracking-*`.
+- **Do NOT** convert content typography (section titles, body, controls). Over-applying Safiro is what kills the signal — when a surface is ambiguous, leave it Google Sans Flex and note it in the inventory.
+- This is a deliberate review-and-apply sweep, not a blanket find-replace.
+
+## Change Log
+
+| Date       | Version | Description                                                | Author |
+| ---------- | ------- | ---------------------------------------------------------- | ------ |
+| 2026-05-20 | 0.1     | Initial draft — follow-up to legal-document-modal Safiro change | Claude |

--- a/docs/stories/completed/14.7b.company-context-tools.md
+++ b/docs/stories/completed/14.7b.company-context-tools.md
@@ -77,7 +77,7 @@ This is the second of three stories split from the original 14.7 (Agent Tool Def
 
 ## Dev Notes
 
-**Note:** Two tools originally in this story (`search_company_files`, `get_compliance_history`) were split into **Story 14.7d** on 2026-03-09 due to missing data pipelines. See `docs/stories/14.7d.file-search-compliance-history-tools.md` for details and unblock criteria.
+**Note:** Two tools originally in this story (`search_company_files`, `get_compliance_history`) were split into **Story 14.7d** on 2026-03-09 due to missing data pipelines. Story 14.7d was later **archived (2026-05-20)** as superseded by Epic 19 Stories 19.2 / 19.3 / 19.4 — see `docs/stories/archived/14.7d.file-search-compliance-history-tools.md`.
 
 ### Previous Story Insights
 

--- a/docs/stories/completed/P.6.laglistor-load-fan-out-elimination.story.md
+++ b/docs/stories/completed/P.6.laglistor-load-fan-out-elimination.story.md
@@ -1,0 +1,241 @@
+# Story P.6: Laglistor Load — Per-Row Server-Action Fan-out Elimination
+
+**Epic:** Performance Optimization (PERF-001)
+**Epic Link:** [docs/performance-epic-executive-summary.md](../../performance-epic-executive-summary.md)
+**Shipped commit:** `bdbdf1c` (branch `doc-fixing`)
+
+## Status
+
+Done
+
+## Story
+
+**As a** Laglig.se user opening or refreshing (F5) a law list,
+**I want** the list to render without firing dozens of redundant server requests,
+**so that** the page loads quickly and the server/log noise stays low.
+
+## Context
+
+A user reported that navigating back to `/laglistor` (via the legal-modal breadcrumb)
+or hard-refreshing it produced "a lot of stuff going on in the logs" and a sluggish
+render. A Vercel log export showed **288 `POST /laglistor` calls over ~217s, arriving in
+bursts of 40–50 within ~3 seconds** on each list load.
+
+Root cause: the "Kravpunkter" column rendered `KravpunkterCountCell` for **every visible
+row**, and each cell independently called the `getRequirementsForListItem` server action
+via SWR on mount (`compliance-detail-table.tsx`). Lists virtualize only above 100 rows
+(`VIRTUALIZATION_THRESHOLD = 100`), so a 40–50 item list rendered every row → one full
+round-trip per row (middleware → JWT → `withWorkspace` auth → Prisma query with deep
+`evidence_links` joins). The grouped view reuses `ComplianceDetailTable` per group, so the
+fan-out multiplied further. This was the dominant source of the log noise and the
+post-load sluggishness — a classic N+1 server-action fan-out for a column that only needs
+two integers (total + fulfilled).
+
+## Acceptance Criteria
+
+1. The Kravpunkter count pill renders on list load **without** a per-row server-action fetch.
+2. Requirement counts (`total` + `fulfilled`) are batched **once per page** in the existing
+   `getDocumentListItems` server action and travel with each item.
+3. The pill still updates **live** when a user edits kravpunkter in the row expansion / modal
+   (no full page reload required).
+4. Existing cell behavior is preserved: the "+ Lägg till" empty state, the read-only gating,
+   and the "—" rendering for `EJ_TILLAMPLIG` items.
+5. The grouped view inherits the fix with no per-group fan-out (no separate code path).
+6. No regressions: `tsc --noEmit`, `next build`, and the affected unit suites pass; live
+   verification shows **zero** `law_list_item_requirements` queries on a list load.
+
+## Tasks / Subtasks
+
+- [x] **Task 1: Batch requirement counts server-side** (AC: 2)
+  - [x] Add a single grouped `$queryRaw` in `getDocumentListItems` keyed on the page's
+        workspace-scoped list-item ids, mirroring the existing `changeCounts` batch
+  - [x] Use `COUNT(*) FILTER (WHERE is_fulfilled)` to get `total` + `fulfilled` in one query
+  - [x] Build a `requirementCountMap` and attach `requirementTotal`/`requirementFulfilled`
+        to each mapped item next to `pendingChangeCount`
+  - [x] Extend the `DocumentListItem` interface with the two new numeric fields
+- [x] **Task 2: Render the cell from props + subscribe without fetching** (AC: 1, 3, 4)
+  - [x] Add `initialTotal`/`initialFulfilled` props to `KravpunkterCountCellProps`
+  - [x] Replace the fetching `useSWR(key, fetcher, …)` with a non-fetching cache subscription
+        `useSWR(key, null, { revalidateOnMount: false, revalidateIfStale: false, revalidateOnFocus: false })`
+  - [x] Derive counts from live cache when present, else from the server-provided props
+        (`requirements ? requirements.length : initialTotal`, etc.)
+  - [x] Remove the now-dead loading skeleton branch and the orphaned
+        `getRequirementsForListItem` import (keep the `RequirementWithEvidence` type)
+  - [x] Wire the new props in the `kravpunkter` column `cell` definition
+- [x] **Task 3: Cover other DocumentListItem construction sites** (AC: 6)
+  - [x] Add `requirementTotal: 0` / `requirementFulfilled: 0` to the store's optimistic
+        `tempItem` (now a required field)
+  - [x] Update the table test fixture (`createMockItem`) to carry the new fields
+        (it `as`-casts, so it silently omitted them) — also fixed the missing `pendingChangeCount`
+- [x] **Task 4: Verify** (AC: 6)
+  - [x] `pnpm typecheck` — clean
+  - [x] `pnpm vitest run` on document-list + scope-selector suites — 398/398 pass
+  - [x] `pnpm exec eslint` on changed files — clean
+  - [x] `next build` (via pre-push hook) — succeeds, 123 pages generated
+  - [x] Live verification on localhost: server logs show **0** `law_list_item_requirements`
+        queries on a list load; the old 40–50 POST burst is gone
+
+## Dev Notes
+
+### Why batch instead of cache
+
+The items query is **not** server-cached, and a Redis cache for the live items list was
+explicitly rejected (huge invalidation surface — every compliance-status / assignee /
+reorder / add-remove / kravpunkt-toggle mutation would have to bust it). The cell only needs
+two integers, so the right move is to compute them in the **one** query the page already
+runs, exactly like the existing `pendingChangeCount` batch. Auth/workspace context is already
+Redis-cached (5-min TTL via `lib/auth/workspace-context.ts`), so the burst of mount actions
+shares it after the first call.
+
+### Implementation
+
+**Server — `app/actions/document-list.ts` (`getDocumentListItems`):**
+Added, right after the `changeCounts`/`changeCountMap` block:
+
+```ts
+const listItemIds = itemsToReturn.map((item) => item.id)
+const requirementCounts =
+  listItemIds.length > 0
+    ? await prisma.$queryRaw<Array<{ list_item_id: string; total: bigint; fulfilled: bigint }>>`
+        SELECT list_item_id,
+               COUNT(*) AS total,
+               COUNT(*) FILTER (WHERE is_fulfilled) AS fulfilled
+        FROM law_list_item_requirements
+        WHERE list_item_id = ANY(${listItemIds}::text[])
+        GROUP BY list_item_id
+      `
+    : []
+// → requirementCountMap; attach requirementTotal/requirementFulfilled in the items.map(...)
+```
+
+- Table/columns verified against `prisma/schema.prisma` (`@@map("law_list_item_requirements")`,
+  `list_item_id`, `is_fulfilled`); `@@index([list_item_id, position])` covers the lookup.
+- Workspace scoping is inherited — `listItemIds` come from the already workspace-scoped
+  `itemsToReturn` (same as the `documentIds` used by the change-count batch).
+
+**Cell — `components/features/document-list/compliance-detail-table.tsx` (`KravpunkterCountCell`):**
+Renders `initialTotal`/`initialFulfilled` from props and uses a **null-fetcher SWR
+subscription** so it never fetches on mount but still re-renders when the shared key
+(`list-item-requirements:${listItemId}`) is mutated. `KravpunkterChecklist` (the full editor)
+still fetches that key independently on expand, and its optimistic `globalMutate(swrKey, …)`
+calls flow straight into the pill. Cache data wins over the initial props when present.
+
+> SWR 2.3.8 confirmed: `useSWR(key, null, opts)` does not issue a request but stays a cache
+> subscriber, so live updates from the checklist are preserved. Verified via `tsc` + tests.
+
+**Grouped view:** no change needed — `grouped-compliance-table.tsx` /
+`compliance-group-section.tsx` render `ComplianceDetailTable` per group, so they inherit the
+fixed cell. `KravpunkterCountCell` was confirmed to be the **only** per-row fetcher on the table.
+
+### Verification methodology (for future perf work)
+
+- **Server logs**: a clean list load shows **zero** `law_list_item_requirements` queries
+  (previously one per row). Confirmed the kravpunkter fan-out is eliminated.
+- **Browser network**: `mcp__claude-in-chrome__read_network_requests` to count
+  `POST /laglistor` per load (server actions transport as POST to the route, even on localhost).
+
+### Audit findings — separate issues surfaced during verification (NOT fixed here)
+
+Live verification of this fix surfaced a **distinct, pre-existing** load-time fan-out, logged
+here so it isn't lost:
+
+1. **Redundant mount fetches.** `document-list-page-content.tsx` fires overlapping mount
+   `useEffect`s that double up: `fetchItems` (line ~581) **and** `setActiveList` (line ~604,
+   because `activeListId` is null on first mount) both call `getDocumentListItems`; `fetchGroups`
+   fires from both line ~582 and the `activeListId` effect (line ~662). A clean single load = ~10
+   `POST /laglistor` server actions (`getDocumentListItems` ×2, `fetchGroups` ×2,
+   `getWorkspaceMembers`, `getTaskColumns`, sidebar `getUnacknowledgedChangeCount`, …).
+2. **`getUnacknowledgedChanges` slow query (~110ms)** runs on every `/laglistor` RSC render
+   (`laglistor/page.tsx`). The ~13 copies in the original log were cumulative across reloads,
+   not one load — confirmed a clean single reload = one RSC render.
+3. **503s on localhost** were the single-instance dev server choking on the concurrent POST
+   burst while compiling (production/serverless would not 503, but the redundant work still
+   costs). External `va.vercel-scripts.com` 503s are unrelated (analytics CDN).
+
+**Caching landscape** (for reference): auth context (Redis 5-min), per-item modal detail
+(`list-item-details:v3`, Redis 24h, prefetched on hover), document content (`document:`), and
+public browse are cached; the law-list items query, lists, groups, members, columns, and
+`getPublishedTemplates` are **not**. The client-side Zustand store caches items in-memory for
+instant list-switching (5-min staleness + background refresh) but is lost on F5.
+
+### Deferred follow-ups (recommended order)
+
+- **Dedupe the mount fetches** — guard the overlapping effects so `getDocumentListItems` /
+  `fetchGroups` fire once on load (kills the ~10-POST burst and the local 503s). Smallest win.
+- **Persist the Zustand store** (sessionStorage) — the real F5 win: paint instantly from a
+  persisted snapshot with a background revalidate.
+- **Cache `getPublishedTemplates`** (`unstable_cache` + tag-bust on publish) — global,
+  rarely-changing, fetched on every load. Cheap, safe.
+- (Lower priority) index/relocate the `getUnacknowledgedChanges` query out of the blocking render.
+
+> A server-side Redis cache for the live items list was considered and **rejected** as the
+> worst ROI here (invalidation cost ≫ benefit). Dedupe + client persistence are the levers.
+
+### Testing
+
+- **Unit (Vitest):** `tests/unit/components/features/document-list/compliance-detail-table.test.tsx`
+  and `tests/unit/lib/stores/document-list-store.test.ts`. The two zero-requirement cell tests
+  needed the fixture to carry the now-required count fields (cache-seeded pill tests were
+  unaffected because live cache data wins over props).
+- **Gates:** `pnpm typecheck`, `pnpm vitest run` (document-list + scope-selector → 398/398),
+  `pnpm exec eslint` on changed files, and `next build` (pre-push hook).
+
+## Change Log
+
+| Date       | Version | Description                                                                 | Author                                  |
+| ---------- | ------- | --------------------------------------------------------------------------- | --------------------------------------- |
+| 2026-05-21 | 1.0     | Implementation + live verification; documented as completed perf story P.6  | James (Dev Agent — Claude Opus 4.7 1M)  |
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude Opus 4.7 (1M context) (`claude-opus-4-7[1m]`)
+
+### Completion Notes List
+
+1. **Server batch**: One extra grouped query per page load (indexed), mirroring the existing
+   `pendingChangeCount` pattern — no schema migration (read-only against existing columns), so
+   it works on local dev / preview / prod without `prisma migrate`.
+2. **Cell**: Switched to a null-fetcher SWR cache subscription + props; removed the loading
+   skeleton and the orphaned `getRequirementsForListItem` import. Live updates from
+   `KravpunkterChecklist` preserved via the shared SWR key.
+3. **Construction sites**: Only the store's optimistic `tempItem` needed the new required
+   fields in app code (`tsconfig` excludes `tests`/`scripts`); the table test fixture was
+   updated so the zero-requirement assertions pass.
+4. **Verification**: Confirmed live on localhost — zero `law_list_item_requirements` queries on
+   load; pre-push `next build` generated 123 pages with no type errors.
+5. **Scope**: This story covers ONLY the kravpunkter fan-out (shipped). The redundant mount
+   fetches, the `getUnacknowledgedChanges` slow query, and store persistence are documented
+   above as deferred follow-ups, not part of this story.
+
+### File List
+
+**Modified:**
+
+- `app/actions/document-list.ts` — batched requirement-count query; `DocumentListItem` +
+  `requirementTotal`/`requirementFulfilled`; attached in the item mapping
+- `components/features/document-list/compliance-detail-table.tsx` — `KravpunkterCountCell`
+  renders from props + null-fetcher cache subscription; column wiring; import cleanup
+- `lib/stores/document-list-store.ts` — optimistic `tempItem` carries the new fields
+- `tests/unit/components/features/document-list/compliance-detail-table.test.tsx` — fixture
+  carries the new count fields
+
+## QA Results
+
+### Review Date: 2026-05-21
+
+### Reviewed By: Self-verified (Dev Agent)
+
+### Outcome
+
+- **AC 1–5:** met. Pill renders from server-batched props with no per-row fetch; live updates
+  preserved via the shared SWR cache; empty/read-only/`EJ_TILLAMPLIG` states unchanged; grouped
+  view inherits the fix.
+- **AC 6:** met. `tsc --noEmit` clean; `next build` succeeds (123 pages); 398/398 unit tests
+  pass; eslint clean on changed files; live server logs show **0** `law_list_item_requirements`
+  queries on a list load (down from one per row → the 40–50-POST burst is eliminated).
+
+### Gate Status
+
+Gate: **PASS** (shipped on `doc-fixing` @ `bdbdf1c`). Deferred follow-ups tracked in Dev Notes.

--- a/lib/stores/document-list-store.ts
+++ b/lib/stores/document-list-store.ts
@@ -533,6 +533,9 @@ export const useDocumentListStore = create<DocumentListState>()(
           updatedAt: new Date(),
           // Story 8.1: New items have no pending changes
           pendingChangeCount: 0,
+          // New items have no kravpunkter yet
+          requirementTotal: 0,
+          requirementFulfilled: 0,
           document: {
             id: documentInfo.id,
             title: documentInfo.title,

--- a/scripts/setup-avatars-bucket.ts
+++ b/scripts/setup-avatars-bucket.ts
@@ -1,0 +1,126 @@
+/**
+ * Set up Supabase Storage bucket for USER AVATARS
+ *
+ * Story 5.14: Personal Profile & Account Settings ("Min profil")
+ *
+ * Creates a PUBLIC `avatars` bucket (png/jpeg, max 2 MB). Avatars are
+ * non-sensitive and rendered across the app, so a public bucket gives a
+ * stable getPublicUrl() we persist directly to User.avatar_url (no signed
+ * URL refresh needed). Server-side uploads use the service-role client
+ * (lib/supabase/storage.ts pattern), which bypasses RLS for the write path.
+ *
+ * Idempotent: a no-op if the bucket already exists.
+ *
+ * Run ONCE per Supabase project (Preview/dev AND Production):
+ *   pnpm tsx scripts/setup-avatars-bucket.ts
+ */
+
+import * as dotenv from 'dotenv'
+dotenv.config({ path: '.env.local' })
+
+import { createClient } from '@supabase/supabase-js'
+
+const BUCKET_NAME = 'avatars'
+const MAX_SIZE = 2 * 1024 * 1024 // 2 MB
+const ALLOWED_MIME = ['image/png', 'image/jpeg']
+
+async function main() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    console.error(
+      'Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY'
+    )
+    process.exit(1)
+  }
+
+  const supabase = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  })
+
+  console.log('='.repeat(60))
+  console.log('Supabase Storage Setup — User Avatars')
+  console.log('='.repeat(60))
+  console.log(`URL: ${supabaseUrl}`)
+  console.log(
+    `Bucket: ${BUCKET_NAME} (public, ${MAX_SIZE / 1024 / 1024} MB, ${ALLOWED_MIME.join('/')})`
+  )
+  console.log()
+
+  const { data: buckets, error: listError } =
+    await supabase.storage.listBuckets()
+
+  if (listError) {
+    console.error('Error listing buckets:', listError.message)
+    process.exit(1)
+  }
+
+  console.log(
+    'Existing buckets:',
+    buckets?.map((b) => b.name).join(', ') || 'none'
+  )
+
+  const existingBucket = buckets?.find((b) => b.name === BUCKET_NAME)
+
+  if (existingBucket) {
+    console.log(`\nBucket "${BUCKET_NAME}" already exists — nothing to do.`)
+    console.log(`  - ID: ${existingBucket.id}`)
+    console.log(`  - Public: ${existingBucket.public}`)
+    console.log(`  - Created: ${existingBucket.created_at}`)
+    if (!existingBucket.public) {
+      console.warn(
+        '\n⚠  Bucket exists but is PRIVATE. Story 5.14 expects a PUBLIC bucket so' +
+          ' avatar_url can be stored as a stable public URL. Update it in the' +
+          ' Supabase dashboard (Storage → avatars → Make public) if needed.'
+      )
+    }
+    return
+  }
+
+  console.log(`\nCreating bucket "${BUCKET_NAME}"...`)
+
+  const { data, error } = await supabase.storage.createBucket(BUCKET_NAME, {
+    public: true,
+    fileSizeLimit: MAX_SIZE,
+    allowedMimeTypes: ALLOWED_MIME,
+  })
+
+  if (error) {
+    console.error('Error creating bucket:', error.message)
+    process.exit(1)
+  }
+
+  console.log('Bucket created successfully!')
+  console.log(`  - Name: ${data.name}`)
+
+  // Smoke-test upload
+  console.log('\nTesting upload capability...')
+  // 1x1 transparent PNG
+  const onePxPng = Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+    'base64'
+  )
+  const testPath = '_test/upload-test.png'
+
+  const { error: uploadError } = await supabase.storage
+    .from(BUCKET_NAME)
+    .upload(testPath, onePxPng, { contentType: 'image/png', upsert: true })
+
+  if (uploadError) {
+    console.error('Upload test failed:', uploadError.message)
+  } else {
+    console.log('Upload test passed!')
+    await supabase.storage.from(BUCKET_NAME).remove([testPath])
+    console.log('Test file cleaned up.')
+  }
+
+  console.log('\n' + '='.repeat(60))
+  console.log('Setup complete!')
+  console.log('='.repeat(60))
+  console.log(
+    `\nStorage path pattern: ${BUCKET_NAME}/<userId>/avatar-<timestamp>.<ext>`
+  )
+}
+
+main().catch(console.error)

--- a/tests/unit/components/features/compliance-audit/cycle-list/cycle-list-table.test.tsx
+++ b/tests/unit/components/features/compliance-audit/cycle-list/cycle-list-table.test.tsx
@@ -149,8 +149,11 @@ describe('CycleListTable', () => {
     ]
     render(<CycleListTable cycles={onlyClosed} canCreate />)
 
+    expect(screen.getByText('Inga kontroller ännu')).toBeInTheDocument()
     expect(
-      screen.getByText('Du har inga aktiva kontroller just nu.')
+      screen.getByText(
+        'Skapa en efterlevnadskontroll för att visa att ni faktiskt lever upp till lagkraven — och få en delbar rapport på köpet.'
+      )
     ).toBeInTheDocument()
     // CTA also rendered in the empty-state; there are two Skapa kontroll
     // links (header + empty state) when canCreate && empty.

--- a/tests/unit/components/features/document-list/compliance-detail-table.test.tsx
+++ b/tests/unit/components/features/document-list/compliance-detail-table.test.tsx
@@ -178,6 +178,9 @@ function createMockItem(
     complianceNarrativeUpdatedAt: new Date('2026-01-20'),
     complianceNarrativeUpdatedBy: 'user-1',
     updatedAt: new Date('2026-01-20'),
+    pendingChangeCount: 0,
+    requirementTotal: 0,
+    requirementFulfilled: 0,
     document: {
       id: 'doc-1',
       title: 'Arbetsmiljölagen',

--- a/tests/unit/components/features/document-list/legal-document-modal/business-context.test.tsx
+++ b/tests/unit/components/features/document-list/legal-document-modal/business-context.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { BusinessContext } from '@/components/features/document-list/legal-document-modal/business-context'
 import { Accordion } from '@/components/ui/accordion'
@@ -102,8 +102,12 @@ describe('BusinessContext', () => {
       initialContent: 'This law affects our HR processes.',
     })
 
+    // Scope to the display — the collapsed-trigger preview also renders this
+    // text (CSS-hidden when open, but jsdom doesn't apply Tailwind).
     expect(
-      screen.getByText('This law affects our HR processes.')
+      within(screen.getByTestId('rich-text-display')).getByText(
+        'This law affects our HR processes.'
+      )
     ).toBeInTheDocument()
   })
 
@@ -195,8 +199,9 @@ describe('BusinessContext', () => {
 
     // Should be back in view mode showing original content
     await waitFor(() => {
-      expect(screen.getByTestId('rich-text-display')).toBeInTheDocument()
-      expect(screen.getByText('Original content')).toBeInTheDocument()
+      const display = screen.getByTestId('rich-text-display')
+      expect(display).toBeInTheDocument()
+      expect(within(display).getByText('Original content')).toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
## Summary
- **Legal-document modal** — left-panel redesign: six accordions grouped into three collapsible sections (Efterlevnad / Referens / Uppgifter & filer) with per-group fold state persisted to `localStorage`, auto-open on focus/deep-link, rich collapsed-row meta, and Safiro applied to the modal title + group labels (content stays on Google Sans Flex). Group-label count chips dropped — they were static structural counts that trained the eye on noise.
- **Legal-document modal header** — replace the non-clickable two-step `List › DocNumber` breadcrumb with a single clickable laglista link that closes the modal on click and navigates via the canonical query-param route (`/laglistor?list=<listId>`). Doc number is already visible in the title's parenthetical and Detaljer → Dokumentnummer.
- **AI-sammanfattning** — collapse the always-visible blue summary callout into a discreet, default-closed "Visa AI-sammanfattning" inline toggle (Sparkles + chevron) in the badge row, using the existing `<Collapsible>` primitive with neutral chrome. Zero vertical cost when collapsed, so the actionable section accordions are no longer pushed below the fold; the trigger only renders when `aiCommentary` is non-null.
- **Laglistor performance (perf story P.6)** — eliminate the per-row server-action fan-out on list load. The Kravpunkter column fired one `getRequirementsForListItem` POST **per visible row** (~40–50 `POST /laglistor` on each load/refresh). Counts are now batched once in `getDocumentListItems` (single grouped query, mirroring the existing change-count batch) and passed as props; the cell subscribes to the shared SWR cache **without** fetching, so it still updates live when the kravpunkter checklist mutates on expand. Verified live: **zero** `law_list_item_requirements` queries on a list load.
- **Empty-state consistency (Slice A)** — unify the truly-empty state across all five list pages (Styrdokument, Uppgifter, Laglistor, Kontroller, Filer) around the existing `<EmptyState>` primitive. Single title voice (`Inga {entity} ännu`), one icon container (rounded-full muted), and body CTAs that mirror each page's toolbar primary action. Spec doc bumped to v1.1 with new copy conventions. Story 22.11 gains an inventory bullet for empty-state titles.
- **Epic 14 docs cleanup** — renumber the sibling write-tool stories `14.26-14.29 → 14.28-14.31` (14.26/14.27 now belong to the shipped Prompt Caching + Usage Telemetry stories), archive 14.6/14.7d/14.12 as superseded by the Epic 17 DMS pipeline + Epic 19 tool taxonomy, and add the consolidated agent-partner implementation sequence under `docs/plans/`.
- **New stories/docs** — `22.11 Safiro structure/identity typography sweep` (backlog/frontend), a `5.14 user-profile/account-settings` story draft + an avatars-bucket setup script, and the completed perf story `P.6` documenting the laglistor fan-out fix above.
- **Prototypes** — `_prototypes/legal-modal-left-panel-redesign.html`, `_prototypes/split-screen-login-changelog.html`, `_prototypes/empty-state-consistency.html` (the audit + proposal that drove the Slice A change), `_prototypes/law-item-timeline-panel.html` (now also hosts the AI-sammanfattning packaging variants A–D that drove the collapse decision).

## Commits
1. `ea1c147` docs(agent-partner): renumber Epic 14 siblings, archive superseded stories, add implementation sequence
2. `730ddd1` chore: add UI prototypes + refresh scheduled-tasks lock
3. `9d5c4f6` feat(legal-modal): redesign left panel — grouped collapsible sections, rich rows, Safiro
4. `b59be80` refactor(legal-modal): collapse header breadcrumb to a single list link
5. `6789be0` feat(empty-states): unify truly-empty across 5 list pages (Slice A)
6. `541451d` chore: add law-item timeline-panel prototype
7. `d1f7cb0` refactor(legal-modal): drop static group-label count chips
8. `7c73d6f` fix(legal-modal): breadcrumb link uses ?list= query param, not path segment
9. `1c79999` chore(prototype): explore AI-sammanfattning packaging variants
10. `ad9758b` chore(prototype): neutral chrome on variant C — drop the AI-generic blue stripe
11. `2c3b990` refactor(legal-modal): collapse AI-sammanfattning to a discreet inline toggle
12. `bdbdf1c` perf(laglistor): batch kravpunkter counts server-side, drop per-row fetch fan-out
13. `5664edf` chore: add user-profile story draft and avatars bucket setup script
14. `de26a6a` docs: add completed perf story P.6 — laglistor fan-out elimination

## Test plan

### Legal-document modal
- [x] Open a legal-document modal from a laglista — verify the three accordion groups (Efterlevnad / Referens / Uppgifter & filer) render with chevron + label, **no count chip**
- [x] Toggle each group open/closed; reload the page — group state persists per accordion via `localStorage`
- [x] Deep-link to a row inside a closed group — the parent group auto-opens
- [x] Confirm collapsed narrative rows show a 1-line preview when filled and muted "Ej ifylld" otherwise; row meta hides when the row is open
- [x] Verify the modal title and group labels render in Safiro `font-medium` and content rows in Google Sans Flex
- [x] Click the laglista name in the modal header — modal closes, navigation goes to `/laglistor?list=<listId>` (canonical query-param route, no 404)
- [x] Spot-check that Share / Copy actions still work

### AI-sammanfattning
- [x] Open a modal for a law that has an AI summary — the summary is collapsed behind a "Visa AI-sammanfattning" pill by default; clicking expands it (neutral chrome, not the old blue callout); aria-label flips Visa/Dölj
- [x] A law with no AI summary shows no pill, and the section accordions sit directly under the badge row

### Laglistor performance (P.6)
- [x] Open/refresh a law list with 40+ items — confirm **no burst** of `POST /laglistor` (server logs show 0 `law_list_item_requirements` queries on load); count pills render immediately with the table
- [x] Expand a row / open the modal and toggle a kravpunkt's "uppfylld" — the row's count pill updates **live** without a page reload
- [x] A row with zero kravpunkter shows "+ Lägg till"; an `EJ_TILLAMPLIG` row shows "—"
- [x] Grouped view: same behavior, no per-group fan-out, counts correct per group

### Empty-state consistency
- [x] Styrdokument with empty workspace → "Inga styrdokument ännu" + `+ Nytt dokument` + `Importera`. Switch to Arkiverade → archive icon + "Inga arkiverade dokument". Apply a filter that returns zero → simpler "Inga dokument hittades" (no CTAs).
- [x] Uppgifter with empty workspace → "Inga uppgifter ännu" + `+ Ny uppgift`. Create a task, apply a filter to zero matches → "Inga uppgifter matchar" (existing copy, no body CTA, preserved verbatim for Slice B).
- [x] Laglistor with a list selected but zero items → page-level rich empty with `<LawListPrimaryAction />` + `Importera laglista`. Apply a filter/search to zero matches → existing in-receiver empty (unchanged in Slice A).
- [x] Kontroller with empty workspace on Aktiva tab → "Inga kontroller ännu" + ClipboardCheck icon + new inspirational description + `+ Skapa kontroll`. Switch to Slutförda/Alla → "Inga kontroller matchar det valda filtret." (no CTA — unchanged).
- [x] Filer in an empty root folder → "Inga filer ännu" + `Ladda upp filer` + `Ny mapp`. Navigate into an empty sub-folder → same state.

## Notes
- Lint: 0 errors, 27 warnings (ceiling 30).
- Unit/component tests pass on all affected paths (418/418 in the touched component directories). Integration-test failures observed locally are pre-existing infra issues (missing Upstash token, unconfirmed Supabase email, Prisma FK setup) and don't touch any files modified on this branch.
- **P.6 perf change** verified live on localhost (zero `law_list_item_requirements` queries on a list load; the old 40–50-POST burst is gone) and through the pre-push `next build` (123 pages, no type errors). Documented as a completed story at `docs/stories/completed/P.6.laglistor-load-fan-out-elimination.story.md`, which also records deferred follow-ups (dedupe redundant mount fetches → persist the Zustand store for F5 → cache `getPublishedTemplates`) — none of which are part of this PR.
- Slice B (deferred to a follow-up story): add `variant: 'empty' | 'filtered'` on `<EmptyState>` for a dashed-border icon + "Rensa filter" recovery action; standardize Laglistor's five table-receiver components (compliance-detail-table, document-list-grid, grouped-*) which now only fire for filtered-to-zero after the Slice A lift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
