### PR TITLE
fix(seo): halve sitemap chunk size to 2_500 — GSC processor caps below ~1 MB

### DIFF
--- a/lib/constants/sitemap.ts
+++ b/lib/constants/sitemap.ts
@@ -2,13 +2,19 @@
  * Shared constants for the XML sitemap pipeline.
  *
  * Google caps a single sitemap file at 50,000 URLs / 50 MB. We chunk at
- * 5,000 URLs (~1 MB per chunk) — halved from the original 10K after the
- * GSC processor failed to ingest 2.3 MB children for 5+ weeks while a
- * 100-URL static test sitemap processed in hours. Smaller files reduce
- * the surface area for any quiet size threshold in GSC's pipeline.
+ * 2,500 URLs (~500 KB per chunk) — halved twice from the original 10K.
+ *
+ * Why this size: after the static-file migration shipped, we observed
+ * that chunk 9 (the partial-fill remainder, 2,231 URLs ≈ ~450 KB)
+ * processed to "Success" in GSC on the same day, while chunks 0–8 (5,000
+ * URLs ≈ ~1 MB each) were marked "Sitemap could not be read" — a hard
+ * verdict, not queue lag. So GSC's processor has a quiet size ceiling
+ * somewhere between ~450 KB and ~1 MB. 2,500 URLs/chunk gives ~500 KB
+ * per file, slightly above the proven-working chunk 9 size, comfortably
+ * below the failure point. The resulting ~19 chunks remain trivial.
  *
  * Used by `scripts/generate-sitemaps.ts` (the build-time static generator)
  * and `scripts/count-sitemap-orphans.ts` so the chunk-size math cannot
  * drift between the two.
  */
-export const SITEMAP_CHUNK_SIZE = 5_000
+export const SITEMAP_CHUNK_SIZE = 2_500


### PR DESCRIPTION
## Summary

One-line follow-up to PR #72. After the static-file migration deployed, today's GSC results gave us a concrete size threshold.

## Evidence

| Chunk | URLs | Size | Result |
|--|--|--|--|
| 9 (partial-fill remainder) | 2,231 | ~450 KB | ✓ Success same-day |
| 0–8 (full chunks) | 5,000 | ~1 MB each | ✗ \"Sitemap could not be read\" (Last read = today; hard verdict, not queue lag) |

GSC's processor silently rejects sitemaps above ~1 MB. Chunk 9 is our known-working size; 2,500 URLs (~500 KB) sits between proven-good and known-bad with comfortable margin.

## Change

\`lib/constants/sitemap.ts\` — \`SITEMAP_CHUNK_SIZE\` from \`5_000\` to \`2_500\`. Build-time generator picks up the new value automatically. ~19 children instead of 10. No URL paths change.

## After deploy

GSC needs cleanup again — chunk count grew from 10 to ~19 so the URL set changes. Delete existing children entries, resubmit only \`sitemap-index.xml\`.

## Test plan

- [ ] \`curl https://www.laglig.se/sitemap-index.xml\` lists ~19 children
- [ ] \`curl https://www.laglig.se/sitemaps/sitemap/0.xml | wc -c\` shows ~500 KB (was ~1 MB)
- [ ] Within 24h, all children flip to Success in GSC (per chunk 9's behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)