### PR TITLE
fix(mobile): stack document hero title and CTA on mobile

### DIFF
--- a/components/features/document-hero.tsx
+++ b/components/features/document-hero.tsx
@@ -115,7 +115,7 @@ export function DocumentHero({
 
   return (
     <header className={cn('pb-4', className)}>
-      <div className="flex flex-wrap items-start gap-4">
+      <div className="flex flex-col gap-4 sm:flex-row sm:flex-wrap sm:items-start">
         {/* Theme icon box — hidden on mobile to save space */}
         <div
           className={cn(
@@ -141,7 +141,9 @@ export function DocumentHero({
           </div>
         </div>
 
-        {actions && <div className="shrink-0 self-start">{actions}</div>}
+        {actions && (
+          <div className="shrink-0 self-stretch sm:self-start">{actions}</div>
+        )}
       </div>
 
       {hasQuickInfo && (

--- a/components/features/documents/add-to-law-list-button.tsx
+++ b/components/features/documents/add-to-law-list-button.tsx
@@ -28,7 +28,7 @@ export function AddToLawListButton({
         variant="outline"
         size="sm"
         onClick={() => setOpen(true)}
-        className="gap-1.5"
+        className="w-full justify-center gap-1.5 sm:w-auto"
       >
         <ListPlus className="h-4 w-4" />
         Lägg till i laglista


### PR DESCRIPTION
The DocumentHero rendered the title column (flex-1 min-w-0) and the
action button (shrink-0) as siblings on one flex row, so on narrow
viewports the long title was squeezed into a tall, narrow column while
the 'Lägg till i laglista' CTA sat cramped in the top-right corner.

Stack the hero vertically on mobile (flex-col, switching to flex-row at
sm) so the title spans full width and the CTA drops below it, and make
the add-to-list button full-width on mobile so it reads as a clear
primary action. Desktop layout is unchanged.