### PR TITLE
fix(consent): apply consent updates via gtag stub + Advanced Consent Mode

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -52,9 +52,9 @@ export default function RootLayout({
             <CookieBanner />
             <ConsentSettingsDialog />
           </ThemeProvider>
-          {/* GA4 — mounts only when analytics consent is granted. */}
+          {/* GA4 + Google Ads — Advanced Consent Mode: load always with
+              consent default-denied (set in <head>); cookies gate on consent. */}
           <GoogleAnalytics />
-          {/* Google Ads — mounts only when marketing consent is granted. */}
           <GoogleAds />
         </ConsentProvider>
         {/* Vercel Analytics - Cookieless, GDPR-compliant tracking */}

--- a/components/features/consent/consent-mode-bootstrap.tsx
+++ b/components/features/consent/consent-mode-bootstrap.tsx
@@ -23,6 +23,10 @@ const BOOTSTRAP_SCRIPT = `
     security_storage: 'granted',
     wait_for_update: 500
   });
+  // Advanced Consent Mode: redact ad identifiers while ad_storage is denied,
+  // and pass the ad click id (gclid) via URL when cookies are unavailable.
+  gtag('set', 'ads_data_redaction', true);
+  gtag('set', 'url_passthrough', true);
 `
 
 export function ConsentModeBootstrap() {

--- a/components/features/consent/google-ads.tsx
+++ b/components/features/consent/google-ads.tsx
@@ -1,26 +1,18 @@
-'use client'
-
 /**
- * Loads the Google Ads gtag.js tag (`AW-…`) once the visitor grants the
- * `marketing` consent category. Mirrors <GoogleAnalytics /> — the shared
- * `window.gtag` stub and Consent Mode v2 default-denied state are already set
- * in <head> by <ConsentModeBootstrap />, so loading here only adds the Ads
- * config; conversions are fired imperatively via `trackAdsConversion()`.
+ * Mounts the Google Ads gtag.js tag (`AW-…`). Advanced Consent Mode: the tag
+ * loads on every page (not gated on consent), with the `consent default` denied
+ * state set in <head> by <ConsentModeBootstrap /> ensuring no ad cookies until
+ * the user grants `ad_storage`. Conversions are fired imperatively via
+ * `trackAdsConversion()`.
  *
- * Renders nothing when `NEXT_PUBLIC_GOOGLE_ADS_ID` is unset (dev / preview) or
- * when marketing consent hasn't been granted.
+ * Renders nothing when `NEXT_PUBLIC_GOOGLE_ADS_ID` is unset (dev / preview).
  */
 
 import Script from 'next/script'
-import { useConsent } from '@/components/providers/consent-provider'
 import { GOOGLE_ADS_ID } from '@/lib/marketing/google-ads'
 
 export function GoogleAds() {
-  const { hydrated, categories } = useConsent()
-
   if (!GOOGLE_ADS_ID) return null
-  if (!hydrated) return null
-  if (!categories.marketing) return null
 
   return (
     <>

--- a/components/features/consent/google-analytics.tsx
+++ b/components/features/consent/google-analytics.tsx
@@ -1,27 +1,19 @@
-'use client'
-
 /**
- * Mounts the GA4 script tag once consent for analytics_storage is granted.
- * Consent Mode v2's default-denied bootstrap (set in `<head>` via
- * ConsentModeBootstrap) means GA4 will still queue + redact even if it
- * loaded with denied state — but we keep it gated here too as
- * belt-and-suspenders and to avoid the script weight when the user has
- * declined.
+ * Mounts the GA4 tag. Advanced Consent Mode: the tag loads on every page (not
+ * gated on consent), and the `consent default` denied state set in <head> by
+ * <ConsentModeBootstrap /> — which runs before this afterInteractive script —
+ * guarantees no cookies until the user grants `analytics_storage`. Denied
+ * (cookieless) pings still flow, feeding GA4's behavioral/conversion modeling.
  *
- * Renders nothing when `NEXT_PUBLIC_GA_ID` is unset (preview / dev) or
- * when consent hasn't been granted.
+ * Renders nothing when `NEXT_PUBLIC_GA_ID` is unset (preview / dev).
  */
 
 import Script from 'next/script'
-import { useConsent } from '@/components/providers/consent-provider'
 
 export function GoogleAnalytics() {
-  const { hydrated, categories } = useConsent()
   const gaId = process.env.NEXT_PUBLIC_GA_ID
 
   if (!gaId) return null
-  if (!hydrated) return null
-  if (!categories.analytics) return null
 
   return (
     <>
@@ -37,7 +29,7 @@ export function GoogleAnalytics() {
         dangerouslySetInnerHTML={{
           __html: `
             gtag('js', new Date());
-            gtag('config', '${gaId}', { anonymize_ip: true });
+            gtag('config', '${gaId}');
           `,
         }}
       />

--- a/lib/consent/gtag.ts
+++ b/lib/consent/gtag.ts
@@ -37,8 +37,11 @@ declare global {
 
 function gtag(...args: unknown[]): void {
   if (typeof window === 'undefined') return
-  window.dataLayer = window.dataLayer ?? []
-  window.dataLayer.push(args)
+  // Delegate to the global stub installed in <head> by <ConsentModeBootstrap />,
+  // which does `dataLayer.push(arguments)`. gtag.js only recognizes consent
+  // commands pushed as an `arguments` object; pushing a plain array (as this
+  // helper used to) is silently ignored, leaving consent stuck at default-denied.
+  window.gtag?.(...args)
 }
 
 export function categoriesToConsentParams(

--- a/tests/unit/lib/consent/gtag.test.ts
+++ b/tests/unit/lib/consent/gtag.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { applyConsent, categoriesToConsentParams } from '@/lib/consent/gtag'
+
+describe('categoriesToConsentParams', () => {
+  it('maps marketing → ad signals and analytics → analytics_storage', () => {
+    const params = categoriesToConsentParams({
+      analytics: true,
+      marketing: true,
+    })
+    expect(params.analytics_storage).toBe('granted')
+    expect(params.ad_storage).toBe('granted')
+    expect(params.ad_user_data).toBe('granted')
+    // ad_personalization stays denied until we run remarketing audiences.
+    expect(params.ad_personalization).toBe('denied')
+  })
+
+  it('denies ad + analytics storage when categories are off', () => {
+    const params = categoriesToConsentParams({
+      analytics: false,
+      marketing: false,
+    })
+    expect(params.analytics_storage).toBe('denied')
+    expect(params.ad_storage).toBe('denied')
+    expect(params.ad_user_data).toBe('denied')
+  })
+})
+
+describe('applyConsent', () => {
+  const gtag = vi.fn()
+
+  beforeEach(() => {
+    gtag.mockReset()
+    // The global stub installed by <ConsentModeBootstrap /> in <head>.
+    ;(window as unknown as { gtag?: typeof gtag }).gtag = gtag
+  })
+
+  afterEach(() => {
+    delete (window as unknown as { gtag?: typeof gtag }).gtag
+  })
+
+  // Regression guard: the consent update MUST go through the global gtag stub
+  // (which does `dataLayer.push(arguments)`). A prior bug pushed a plain array
+  // to dataLayer, which gtag.js silently ignores — leaving consent default-denied
+  // and breaking all GA4/Ads measurement.
+  it('issues the consent update via the global gtag stub (not a raw array push)', () => {
+    applyConsent({ analytics: true, marketing: true })
+
+    expect(gtag).toHaveBeenCalledTimes(1)
+    const [command, action, params] = gtag.mock.calls[0]
+    expect(command).toBe('consent')
+    expect(action).toBe('update')
+    expect(params).toMatchObject({
+      analytics_storage: 'granted',
+      ad_storage: 'granted',
+      ad_user_data: 'granted',
+    })
+  })
+})


### PR DESCRIPTION
## The bug (why GA4 had 0 data for weeks)

`lib/consent/gtag.ts`'s `gtag()` helper pushed consent commands to `dataLayer` as a **plain array** (`dataLayer.push(args)`). `gtag.js` only honors consent commands pushed as the `arguments` **object** (the canonical `function gtag(){dataLayer.push(arguments)}` pattern the `<head>` bootstrap uses). So every `gtag('consent','update', …)` was **silently ignored** — consent stayed at the default `denied`.

**Verified live on production** (chrome-devtools): even immediately after a user clicks "Acceptera alla", GA4 hits went out with `gcs=G100` (analytics + ad storage denied). GA4 discards denied/cookieless hits from Realtime + standard reports → "no data received." This **also broke Google Ads conversions** (ad_storage stuck denied). Re-issuing the update through the arguments-stub flipped the next hit to `gcs=G111` (granted) — proving the fix.

### Fix
Route the consent helper through the global `window.gtag` arguments-stub (installed in `<head>` before any client code).

## Advanced Consent Mode (best practice for running ads)

Previously the tags were **script-gated** — `gtag.js` didn't load until consent was granted (Basic mode), so non-consenting visitors were invisible and GA showed "data collection isn't active." Switched to **Advanced Consent Mode** (Google-recommended):
- GA4 + Google Ads tags now load on **every** page, with `consent default: denied` set in `<head>` first → no cookies until consent, but cookieless pings flow and feed conversion/behavioral **modeling** (materially better Ads bidding).
- Added `ads_data_redaction` + `url_passthrough` to the consent bootstrap.

The cookie banner + settings dialog are **unchanged** — consent still gates cookies (`ad_storage`/`analytics_storage`), we just removed the script-load gate.

## Verification
- `tsc` ✅ · `eslint` ✅ · `vitest` 67/67 ✅ (incl. new regression test guarding the array-vs-arguments bug)
- Post-deploy (production): fresh load → `gtag/js` loads + `gcs=G100` cookieless ping; accept all → next hit `gcs=G111`; GA4 Realtime shows the user within ~30s; "not active" banner clears in 24–48h.

## Follow-up (not in this PR)
- `/cookiepolicy` + `/integritetspolicy` should disclose Consent Mode (cookieless pings sent pre-consent). Legal copy — left for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)