### PR TITLE
copy(hero): sell the complete compliance system in the subtitle

### DIFF
--- a/components/features/landing-v3/hero-v3.tsx
+++ b/components/features/landing-v3/hero-v3.tsx
@@ -37,10 +37,9 @@ export function HeroV3() {
 
           <div className="mb-10 flex animate-fade-up-delay-2 flex-col items-start gap-6 lg:flex-row lg:items-end lg:justify-between">
             <p className="max-w-xl text-lg text-muted-foreground md:text-xl">
-              Laglig är hela ert system för lagefterlevnad — laglistan som
-              håller sig aktuell av sig själv, AI:n som tolkar varje
-              regeländring åt er, och kontrollerna och dokumenten som gör er
-              revisionsklara när som helst.
+              Laglig samlar alla regler som gäller just er verksamhet, håller
+              dem aktuella när lagarna ändras, och hjälper er bevisa att ni
+              följer dem — utan att ni behöver vara experter.
             </p>
             <OrgCheckForm
               eyebrow="Testa direkt · 30 sek"

--- a/components/features/landing-v3/hero-v3.tsx
+++ b/components/features/landing-v3/hero-v3.tsx
@@ -37,9 +37,10 @@ export function HeroV3() {
 
           <div className="mb-10 flex animate-fade-up-delay-2 flex-col items-start gap-6 lg:flex-row lg:items-end lg:justify-between">
             <p className="max-w-xl text-lg text-muted-foreground md:text-xl">
-              Oavsett var ni står idag — Laglig skapar er laglista, bevakar
-              ändringarna och säger vad de betyder för just er. AI-grundad i
-              svensk rätt.
+              Laglig är hela ert system för lagefterlevnad — laglistan som
+              håller sig aktuell av sig själv, AI:n som tolkar varje
+              regeländring åt er, och kontrollerna och dokumenten som gör er
+              revisionsklara när som helst.
             </p>
             <OrgCheckForm
               eyebrow="Testa direkt · 30 sek"


### PR DESCRIPTION
## What

Rewrites the landing hero subtitle (`components/features/landing-v3/hero-v3.tsx`) so it sells the **whole product**, not just lagbevakning.

**Before:**
> Oavsett var ni står idag — Laglig skapar er laglista, bevakar ändringarna och säger vad de betyder för just er. AI-grundad i svensk rätt.

**After:**
> Laglig är hela ert system för lagefterlevnad — laglistan som håller sig aktuell av sig själv, AI:n som tolkar varje regeländring åt er, och kontrollerna och dokumenten som gör er revisionsklara när som helst.

## Why

Compliance is three jobs: **veta** vad som gäller (laglista), **hänga med** när det ändras (bevakning + AI), and **bevisa** att ni följer det (kontroller, styrdokument, revisionsunderlag). The old subtitle only sold the first two — the entire audit-readiness side of the product was invisible, and the "Oavsett var ni står idag —" opener was filler.

New copy makes the "complete system" claim explicit and names the full lifecycle from laglista → revision, ending on the outcome buyers care about (*revisionsklara när som helst*).

Headline ("Håll koll på lagarna. Automatiskt.") is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)