### PR TITLE
feat(marketing): Lead component, breadcrumb removal + Epic 26 page-inventory plan

### DIFF
--- a/app/(marketing)/layout.tsx
+++ b/app/(marketing)/layout.tsx
@@ -4,8 +4,8 @@ import { ForceLightTheme } from '@/components/features/landing-v2/force-light-th
  * Route-group layout for /funktioner, /branscher, /omraden (Story 26.1).
  *
  * Forces light theme to match the homepage (the landing-v3 chrome is
- * light-only). The MarketingShell itself (NavbarV3 + breadcrumbs + FooterV3)
- * is rendered by the page templates, which own the per-page breadcrumb data.
+ * light-only). The MarketingShell itself (NavbarV3 + FooterV3) is rendered by
+ * the page templates that wrap each marketing page's content.
  */
 export default function MarketingLayout({
   children,

--- a/components/marketing/mdx/lead.tsx
+++ b/components/marketing/mdx/lead.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from 'react'
+
+/**
+ * Standfirst/deck for a marketing article's lede. Authors wrap the opening
+ * sentence in `<Lead>…</Lead>` in MDX; Prettier reflows that to block form, so
+ * the child is a real `<p>` (which keeps the centered PROSE width from the
+ * global `p` mapping in mdx-components.tsx). We restyle that child here — bigger
+ * and in the ink color — via `[&>p]`, so the lede reads as an intentional intro
+ * rather than orphaned body text under the hero, with no heading competing with
+ * the H1.
+ *
+ * Lives under components/ (not inline in mdx-components.tsx) so Tailwind's
+ * content scan actually generates these `[&>p]:` arbitrary-variant utilities —
+ * the repo root is outside the content globs.
+ */
+export function Lead({ children }: { children: ReactNode }) {
+  return (
+    <div className="[&>p]:mb-2 [&>p]:mt-1 [&>p]:text-lg [&>p]:leading-relaxed [&>p]:text-foreground/90 sm:[&>p]:text-xl">
+      {children}
+    </div>
+  )
+}

--- a/components/marketing/sections/hero-org-check.tsx
+++ b/components/marketing/sections/hero-org-check.tsx
@@ -39,21 +39,21 @@ export function HeroOrgCheck({
   return (
     <div className="w-full max-w-md">
       <OrgCheckForm
-        eyebrow="Testa direkt · 30 sek"
+        eyebrow="Se vilka regler som gäller er · 30 sek"
         resultMode="modal"
         onPreviewSuccess={onPreviewSuccess}
       />
       <p className="mt-3 pl-1 text-xs text-muted-foreground">
-        Eller{' '}
+        Vill du hellre starta direkt?{' '}
         <Link
           href={secondaryUrl}
           onClick={onSecondaryClick}
           className="inline-flex items-center gap-0.5 font-medium text-foreground underline-offset-2 hover:underline"
         >
-          {ctaLabel.toLowerCase()} direkt
+          {ctaLabel.toLowerCase()} i 15 dagar
           <ArrowRight className="h-3 w-3" />
         </Link>{' '}
-        · 15 dagar, inget betalkort krävs.
+        · inget betalkort krävs.
       </p>
     </div>
   )

--- a/components/marketing/templates/base-page-template.tsx
+++ b/components/marketing/templates/base-page-template.tsx
@@ -11,7 +11,6 @@ import {
   type RelatedPage,
 } from '@/components/marketing/sections/related-pages-grid'
 import {
-  MARKETING_KIND_LABELS,
   type MarketingFrontmatter,
   type MarketingKind,
 } from '@/lib/marketing/frontmatter-schemas'
@@ -81,12 +80,7 @@ export function BasePageTemplate({
   const related = resolveRelatedPages(fm.relatedPages)
 
   return (
-    <MarketingShell
-      breadcrumbs={[
-        { label: MARKETING_KIND_LABELS[kind] },
-        { label: fm.title, current: true },
-      ]}
-    >
+    <MarketingShell>
       <MarketingHero
         eyebrow={fm.heroEyebrow}
         title={fm.heroTitle}

--- a/components/marketing/templates/marketing-shell.tsx
+++ b/components/marketing/templates/marketing-shell.tsx
@@ -1,5 +1,3 @@
-import Link from 'next/link'
-import { ChevronRight } from 'lucide-react'
 import { NavbarV3 } from '@/components/features/landing-v3/navbar-v3'
 import { FooterV3 } from '@/components/features/landing-v3/footer-v3'
 import { getPublishedMarketingRoutes } from '@/lib/marketing/content'
@@ -10,52 +8,17 @@ import { getPublishedMarketingRoutes } from '@/lib/marketing/content'
  * Composes the LANDING-V3 chrome — not components/shared/navigation — so the
  * conversion funnel is visually continuous from `/` (decision recorded in
  * Epic 26 v0.2). Story 26.2 points NavbarV3's megamenu at these routes.
+ *
+ * No breadcrumb row: the hero eyebrow ("Bransch · Restaurang & hotell") already
+ * orients the visitor, and the megamenu navbar handles up-navigation — a
+ * separate "Hem › Branscher › …" trail was redundant and heavier-looking.
  */
-export function MarketingShell({
-  breadcrumbs,
-  children,
-}: {
-  /** e.g. [{ label: 'Branscher' }, { label: 'Bygg', current: true }] */
-  breadcrumbs: Array<{ label: string; href?: string; current?: boolean }>
-  children: React.ReactNode
-}) {
+export function MarketingShell({ children }: { children: React.ReactNode }) {
   const publishedRoutes = getPublishedMarketingRoutes()
 
   return (
     <div className="flex min-h-screen flex-col bg-background">
       <NavbarV3 publishedRoutes={publishedRoutes} />
-      <nav
-        aria-label="Brödsmulor"
-        className="container mx-auto px-4 pt-6 text-xs text-muted-foreground"
-      >
-        <ol className="flex flex-wrap items-center gap-1.5">
-          <li>
-            <Link href="/" className="transition-colors hover:text-foreground">
-              Hem
-            </Link>
-          </li>
-          {breadcrumbs.map((crumb) => (
-            <li key={crumb.label} className="flex items-center gap-1.5">
-              <ChevronRight aria-hidden className="h-3 w-3" />
-              {crumb.href && !crumb.current ? (
-                <Link
-                  href={crumb.href}
-                  className="transition-colors hover:text-foreground"
-                >
-                  {crumb.label}
-                </Link>
-              ) : (
-                <span
-                  aria-current={crumb.current ? 'page' : undefined}
-                  className="font-medium text-foreground"
-                >
-                  {crumb.label}
-                </span>
-              )}
-            </li>
-          ))}
-        </ol>
-      </nav>
       <main className="flex-1">{children}</main>
       <FooterV3 publishedRoutes={publishedRoutes} />
     </div>

--- a/content/marketing/branscher/bygg.mdx
+++ b/content/marketing/branscher/bygg.mdx
@@ -60,7 +60,11 @@ faq:
     answer: 'Från 1 januari 2025 ersattes de gamla föreskrifterna av en ny struktur där bland annat AFS 2023:3 samlar byggherrens, projektörers och BAS-P/BAS-U:s skyldigheter. Laglistor som fortfarande pekar på äldre AFS:ar måste uppdateras. Under 2026 sänks dessutom gränsvärden för bland annat diisocyanater och krom (VI), vilket påverkar arbeten med fogskum, lim och betong.'
 ---
 
-Få branscher har en så tät och föränderlig regelkarta som bygg och anläggning. Arbetsmiljölagen med tjocka buntar av AFS:ar, plan- och bygglagen, miljöbalken, klimatdeklarationer, personalliggare, elsäkerhet — kraven kommer från flera myndigheter samtidigt och ändras ofta. Att veta _vilka_ av dem som faktiskt gäller just era arbeten, och att hålla koll när de ändras, är ett heltidsjobb i sig.
+<Lead>
+  Få branscher har en så tät och föränderlig regelkarta som bygg och anläggning.
+</Lead>
+
+Arbetsmiljölagen med tjocka buntar av AFS:ar, plan- och bygglagen, miljöbalken, klimatdeklarationer, personalliggare, elsäkerhet — kraven kommer från flera myndigheter samtidigt och ändras ofta. Att veta _vilka_ av dem som faktiskt gäller just era arbeten, och att hålla koll när de ändras, är ett heltidsjobb i sig.
 
 Laglig samlar hela bilden på ett ställe: en laglista som är kopplad till er verksamhet, med en kort förklaring av varför varje lag gäller er, status på efterlevnaden och bevakning av ändringar — så att ni alltid är redo för en revision eller en inspektion från Arbetsmiljöverket.
 

--- a/content/marketing/branscher/fastighet.mdx
+++ b/content/marketing/branscher/fastighet.mdx
@@ -65,7 +65,15 @@ faq:
     answer: 'Hela kartan: PBL med plan- och byggförordningen (OVK, hissar, underhåll), miljöbalken med egenkontrollen, energideklarationslagen, lagen om skydd mot olyckor med SBA, elsäkerhetslagen, strålskyddslagen för radon, jordabalkens hyreskapitel samt arbetsmiljölagen med AFS-föreskrifterna för er egen personal — plus besiktningsintervallen per byggnad. En branschanpassad laglista med lagbevakning konkretiserar och uppdaterar den.'
 ---
 
-Få verksamheter har sina lagkrav så utspridda som fastighetsägarens: bygglagstiftningen säger när OVK och hisskontroller ska göras, miljöbalken kräver egenkontroll mot allt från radon till legionella, lagen om skydd mot olyckor lägger brandskyddet på ert bord, elsäkerhetslagen gör er till ansvarig innehavare och jordabalken styr förhållandet till hyresgästerna. Ingen myndighet visar helheten — kraven kommer från Boverket, kommunen, räddningstjänsten, Elsäkerhetsverket och miljöförvaltningen samtidigt.
+<Lead>
+  Få verksamheter har sina lagkrav så utspridda som fastighetsägarens:
+  bygglagstiftningen säger när OVK och hisskontroller ska göras, miljöbalken
+  kräver egenkontroll mot allt från radon till legionella, lagen om skydd mot
+  olyckor lägger brandskyddet på ert bord, elsäkerhetslagen gör er till ansvarig
+  innehavare och jordabalken styr förhållandet till hyresgästerna.
+</Lead>
+
+Ingen myndighet visar helheten — kraven kommer från Boverket, kommunen, räddningstjänsten, Elsäkerhetsverket och miljöförvaltningen samtidigt.
 
 Laglig samlar hela kartan i en laglista för fastighetsbolag och förvaltare: varje lag med en förklaring av varför den gäller just ert bestånd, status på efterlevnaden och bevakning när reglerna ändras. Det som gör fastighet speciellt — att kraven återkommer per byggnad, år efter år — är precis det en laglista med kravpunkter är byggd för.
 

--- a/content/marketing/branscher/hotell-restaurang.mdx
+++ b/content/marketing/branscher/hotell-restaurang.mdx
@@ -53,7 +53,13 @@ faq:
     answer: 'Utöver arbetsmiljölagen (1977:1160) är AFS 2023:1 om systematiskt arbetsmiljöarbete grunden. Särskilt relevanta är belastningsergonomi (tunga lyft i kök), kemiska risker (rengöringsmedel), buller, ensamarbete och hot/våld mot personal i servering och reception — allt reglerat i Arbetsmiljöverkets nya föreskriftsstruktur som gäller från 2025.'
 ---
 
-Restaurang- och hotellverksamhet är en av de mest reglerade branscherna som finns: ni lyder under livsmedelslagstiftning, alkohollagstiftning, brandskydd, arbetsmiljö, tobaksregler och konsumenträtt — ofta samtidigt, i samma lokal. Problemet är sällan att hitta en enskild lag, utan att veta _vilka_ av tusentals paragrafer som faktiskt berör just er verksamhet, och att hålla koll när de ändras.
+<Lead>
+  Restaurang- och hotellverksamhet är en av de mest reglerade branscherna som
+  finns: ni lyder under livsmedelslagstiftning, alkohollagstiftning, brandskydd,
+  arbetsmiljö, tobaksregler och konsumenträtt — ofta samtidigt, i samma lokal.
+</Lead>
+
+Problemet är sällan att hitta en enskild lag, utan att veta _vilka_ av tusentals paragrafer som faktiskt berör just er verksamhet, och att hålla koll när de ändras.
 
 Laglig samlar hela den bilden på ett ställe. I stället för spridda pärmar och ett kalkylark som ingen öppnar får ni en laglista som är kopplad till er verksamhet — med en kort förklaring av varför varje lag gäller er, status på efterlevnaden och bevakning av ändringar.
 

--- a/content/marketing/branscher/industri.mdx
+++ b/content/marketing/branscher/industri.mdx
@@ -68,7 +68,14 @@ faq:
     answer: 'Maskinförordningen (EU) 2023/1230 ersätter maskindirektivet och blir direkt gällande den 20 januari 2027, utan svensk omskrivning. Nyheter: krav kring AI och självlärande funktioner, cybersäkerhet som säkerhetsfråga, digitala bruksanvisningar och ändrade förfaranden för högriskmaskiner. Den berör både maskintillverkare och den som bygger om eller integrerar maskiner — lagbevakningen flaggar i god tid.'
 ---
 
-Ett tillverkande företag bär fyra tunga regelområden samtidigt: maskinsäkerheten och arbetsmiljön på golvet, kemikalierna i processerna, miljöbalkens krav på själva anläggningen och energi- och brandkraven runt omkring. Reglerna kommer från Arbetsmiljöverket, Kemikalieinspektionen, Naturvårdsverket, kommunen och EU — och de ändras i otakt: AFS-strukturen gjordes om 2025, gränsvärden sänks 2026, maskinförordningen tar över 2027.
+<Lead>
+  Ett tillverkande företag bär fyra tunga regelområden samtidigt:
+  maskinsäkerheten och arbetsmiljön på golvet, kemikalierna i processerna,
+  miljöbalkens krav på själva anläggningen och energi- och brandkraven runt
+  omkring.
+</Lead>
+
+Reglerna kommer från Arbetsmiljöverket, Kemikalieinspektionen, Naturvårdsverket, kommunen och EU — och de ändras i otakt: AFS-strukturen gjordes om 2025, gränsvärden sänks 2026, maskinförordningen tar över 2027.
 
 Laglig samlar hela kartan i en laglista för er verkstad: varje lag och föreskrift med en förklaring av varför den gäller er produktion, kravpunkter som gör paragraferna till checklistor och bevakning som fångar ändringarna — så att ISO-revisionen och myndighetstillsynen möter dokumentation i stället för ett kalkylark.
 

--- a/content/marketing/branscher/it.mdx
+++ b/content/marketing/branscher/it.mdx
@@ -53,7 +53,12 @@ faq:
     answer: 'Det är precis problemet Laglig löser. Cybersäkerhetslagen är det tydligaste exemplet på senare år — ett helt nytt regelverk som ersatte den gamla NIS-lagen (2018:1174). Laglig bevakar ändringarna åt er, låter AI:n bedöma vad de innebär för er verksamhet, och ni granskar och godkänner.'
 ---
 
-IT- och techföretag lever i en av de snabbast föränderliga regelmiljöerna som finns. Dataskydd, cybersäkerhet, elektronisk kommunikation, e-handel, immaterialrätt — kraven kommer från både EU och svensk lagstiftning, och tempot är högt. Den nya cybersäkerhetslagen som genomför NIS2 är bara det senaste exemplet på ett helt regelverk som dykt upp på kort tid.
+<Lead>
+  IT- och techföretag lever i en av de snabbast föränderliga regelmiljöerna som
+  finns.
+</Lead>
+
+Dataskydd, cybersäkerhet, elektronisk kommunikation, e-handel, immaterialrätt — kraven kommer från både EU och svensk lagstiftning, och tempot är högt. Den nya cybersäkerhetslagen som genomför NIS2 är bara det senaste exemplet på ett helt regelverk som dykt upp på kort tid.
 
 Laglig samlar hela bilden på ett ställe: en laglista kopplad till er verksamhet, med en kort förklaring av varför varje lag gäller er, status på efterlevnaden och bevakning av ändringar — så att compliance blir något ni har kontroll över, inte något som överraskar er.
 

--- a/content/marketing/branscher/transport.mdx
+++ b/content/marketing/branscher/transport.mdx
@@ -66,7 +66,15 @@ faq:
     answer: 'Yrkeskompetensbeviset är personligt, men företaget riskerar ansvar och stoppade transporter om en förare kör utan giltigt bevis — 35 timmars fortbildning vart femte år enligt lagen om yrkesförarkompetens. Från den 1 september 2026 får upp till 12 av timmarna genomföras på distans. En kravpunkt på er rutin för YKB-bevakning gör ansvaret spårbart — och revideras vid varje lagefterlevnadskontroll.'
 ---
 
-Ett åkeri lever närmare sina lagkrav än de flesta: kör- och vilotiderna registreras i färdskrivaren varje arbetsdag, Transportstyrelsens företagskontroller utgår från ett riskvärde som varje överträdelse höjer, och hela verksamheten vilar på ett trafiktillstånd som kräver fortsatt gott anseende. Ovanpå det: YKB-fortbildningar som förfaller per förare, ADR-regler som revideras vartannat år, vägarbetstidslagen, arbetsmiljökraven på terminalen.
+<Lead>
+  Ett åkeri lever närmare sina lagkrav än de flesta: kör- och vilotiderna
+  registreras i färdskrivaren varje arbetsdag, Transportstyrelsens
+  företagskontroller utgår från ett riskvärde som varje överträdelse höjer, och
+  hela verksamheten vilar på ett trafiktillstånd som kräver fortsatt gott
+  anseende.
+</Lead>
+
+Ovanpå det: YKB-fortbildningar som förfaller per förare, ADR-regler som revideras vartannat år, vägarbetstidslagen, arbetsmiljökraven på terminalen.
 
 Branschens egen lagbevakning är dessutom borta — medlemstjänsten som länge sammanfattade reglerna lades ner vid årsskiftet 2024/25, och tusentals åkerier hänvisades till att lösa bevakningen själva. Laglig är det öppna alternativet: en laglista för transport och logistik med kravpunkter per lag, löpande bevakning och dokumentation som håller vid företagskontrollen.
 

--- a/content/marketing/branscher/vard-omsorg.mdx
+++ b/content/marketing/branscher/vard-omsorg.mdx
@@ -59,7 +59,15 @@ faq:
     answer: 'Nej — att iordningställa och administrera läkemedel är hälso- och sjukvårdsuppgifter som kräver formell delegering från legitimerad personal, med rutiner och uppföljning i ledningssystemet. Kravpunkter på delegeringsrutiner, kompetenskontroll och årlig uppföljning hålls levande i laglistan.'
 ---
 
-En privat vård- och omsorgsutförare lyder under fler regelgivare än någon annan bransch på de här sidorna: riksdagens lagar, Socialstyrelsens föreskrifter, IVO:s tillståndsvillkor, Arbetsmiljöverkets AFS, Integritetsskyddsmyndighetens dataskyddskrav och kommunens avtalsvillkor — ofta i samma arbetsmoment. Och till skillnad från de flesta branscher är bevakningen inte frivillig: som tillståndshavare förväntas ni hålla er uppdaterade om kraven som gäller verksamheten.
+<Lead>
+  En privat vård- och omsorgsutförare lyder under fler regelgivare än någon
+  annan bransch på de här sidorna: riksdagens lagar, Socialstyrelsens
+  föreskrifter, IVO:s tillståndsvillkor, Arbetsmiljöverkets AFS,
+  Integritetsskyddsmyndighetens dataskyddskrav och kommunens avtalsvillkor —
+  ofta i samma arbetsmoment.
+</Lead>
+
+Och till skillnad från de flesta branscher är bevakningen inte frivillig: som tillståndshavare förväntas ni hålla er uppdaterade om kraven som gäller verksamheten.
 
 Laglig samlar hela regelverket i en laglista för er verksamhet — äldreboende, hemtjänst, LSS eller mottagning — med en förklaring per lag, status på efterlevnaden och löpande bevakning. När IVO kommer är dokumentationen redan gjord.
 

--- a/content/marketing/funktioner/_template.mdx
+++ b/content/marketing/funktioner/_template.mdx
@@ -73,10 +73,20 @@ heroMedia:
 # ogVariant: reserved for future OG-image art direction. Omit.
 ---
 
-Skriv brödtexten här i vanlig markdown. `##`-rubriker blir Safiro-rubriker,
-länkar och listor får sidans typografi automatiskt (se mdx-components.tsx).
+<Lead>
+Inled med EN kort, slagkraftig mening som ramar in problemet.
+</Lead>
+
+Wrappa ingressens första mening i `<Lead>` — den sätts större och i bläckfärg
+som standfirst direkt under hjältesektionen, så att brödtexten inte läses som
+föräldralös under skärmbilden. Bara första meningen; resten av stycket fortsätter
+som vanlig brödtext här. `##`-rubriker blir Safiro-rubriker, länkar och listor
+får sidans typografi automatiskt (se mdx-components.tsx).
 
 Sektionskomponenter droppas in direkt i texten där de behövs:
 
-{/* <SplitFeature> för produktdjup, <CatalogLawList> för laglistan,
+{/* <Lead> omsluter ENBART första meningen (en mening, inte hela stycket).
+    Prettier reflowar den till blockform — det är meningen; se
+    components/marketing/mdx/lead.tsx.
+    <SplitFeature> för produktdjup, <CatalogLawList> för laglistan,
     <FaqAccordion> renderas alltid av mallen — skriv inte ut den här. */}

--- a/content/marketing/funktioner/ai-agent.mdx
+++ b/content/marketing/funktioner/ai-agent.mdx
@@ -44,7 +44,11 @@ faq:
     answer: 'Ja. Standarderna kräver att ni identifierar bindande krav och utvärderar efterlevnaden av dem. Agenten håller laglistan aktuell när kraven ändras och hjälper till med bedömningar, åtgärder och styrdokument — och arbetet dokumenteras i Laglig som underlag inför revision. Själva lagefterlevnadskontrollen genomför ni i kontrollfunktionen; agenten ser till att listan den bygger på alltid är uppdaterad.'
 ---
 
-De flesta compliance-verktyg ger er en lista och lämnar resten till er. Laglig-agenten gör tvärtom: den tar sig an arbetet. Den bevakar lagändringar, bedömer vad de betyder för just er verksamhet, föreslår åtgärder och hjälper till med styrdokument — och allt den gör kan ni granska och godkänna. Tänk på den som en kollega som aldrig sover och alltid har läst hela lagboken, inte som en chattruta.
+<Lead>
+  De flesta compliance-verktyg ger er en lista och lämnar resten till er.
+</Lead>
+
+Laglig-agenten gör tvärtom: den tar sig an arbetet. Den bevakar lagändringar, bedömer vad de betyder för just er verksamhet, föreslår åtgärder och hjälper till med styrdokument — och allt den gör kan ni granska och godkänna. Tänk på den som en kollega som aldrig sover och alltid har läst hela lagboken, inte som en chattruta.
 
 Det som skiljer agenten från en allmän AI är att den arbetar inuti er laglista och mot verklig svensk lagtext. Varje svar har en källa, varje förslag en grund.
 

--- a/content/marketing/funktioner/kontroller.mdx
+++ b/content/marketing/funktioner/kontroller.mdx
@@ -48,7 +48,9 @@ faq:
     answer: 'Det går, men det blir snabbt ospårbart: arket tappar kopplingen till laglistan när lagar ändras, det finns ingen historik mellan åren och avvikelser hanteras vid sidan av. När kontrollen i stället byggs direkt på laglistan hänger krav, bedömning och åtgärd ihop — och revisionsbeläggen skapas medan ni arbetar, inte kvällen innan revisionen.'
 ---
 
-Att ha en laglista är ett krav i de flesta ledningssystem. Men en laglista räcker inte — ni måste också kunna visa att ni _utvärderar_ efterlevnaden av kraven, regelbundet och dokumenterat. Det är där lagefterlevnadskontrollen kommer in, och det är ofta här det skaver: kontrollen lever i ett kalkylark eller en Word-mall som öppnas en gång om året, fylls i på måfå och sedan glöms bort tills nästa revision.
+<Lead>Att ha en laglista är ett krav i de flesta ledningssystem.</Lead>
+
+Men en laglista räcker inte — ni måste också kunna visa att ni _utvärderar_ efterlevnaden av kraven, regelbundet och dokumenterat. Det är där lagefterlevnadskontrollen kommer in, och det är ofta här det skaver: kontrollen lever i ett kalkylark eller en Word-mall som öppnas en gång om året, fylls i på måfå och sedan glöms bort tills nästa revision.
 
 Laglig gör lagefterlevnadskontrollen till en naturlig del av arbetet. Kontrollen byggs direkt på kravpunkterna i er laglista, med ansvar, status och dokumenterat resultat — så att ni alltid är redo att visa upp efterlevnaden.
 

--- a/content/marketing/funktioner/kravpunkter.mdx
+++ b/content/marketing/funktioner/kravpunkter.mdx
@@ -52,7 +52,9 @@ faq:
     answer: 'Kravpunkten är kravet, kontrollen är revisionen av det. Kontrollcyklerna fryser kravpunkterna vid kontrolltillfället och bedömer att rutinerna faktiskt följs — så att samma punkter ni arbetar med till vardags är de ni visar upp vid kontrollen.'
 ---
 
-En laglista säger vilka lagar som gäller er. Men en rad i en lista går inte att agera på — "Arbetsmiljölagen" är inte en uppgift någon kan ta ansvar för. Det som går att agera på är kraven i lagen: att en riskbedömning genomförs och dokumenteras, att en brandskyddsansvarig är utsedd, att en rutin för avvikelsehantering finns och är känd. Det är de kraven som är kravpunkter i Laglig.
+<Lead>En laglista säger vilka lagar som gäller er.</Lead>
+
+Men en rad i en lista går inte att agera på — "Arbetsmiljölagen" är inte en uppgift någon kan ta ansvar för. Det som går att agera på är kraven i lagen: att en riskbedömning genomförs och dokumenteras, att en brandskyddsansvarig är utsedd, att en rutin för avvikelsehantering finns och är känd. Det är de kraven som är kravpunkter i Laglig.
 
 De flesta som söker efter en checklista för lagkrav hittar en Word- eller Excel-mall: en bra start, men ett dokument utan koppling till laglistan, utan ansvariga och utan bevis. Kravpunkterna i Laglig är samma checklista — men som en levande del av er laglista.
 

--- a/content/marketing/funktioner/lagandringar.mdx
+++ b/content/marketing/funktioner/lagandringar.mdx
@@ -46,7 +46,13 @@ faq:
     answer: 'Nyhetsbrevet slutar där jobbet börjar: det säger att något ändrats, inte vad det betyder för er eller vem som gör vad. I Laglig blir varje ändring en bedömning, vid behov en uppgift med ansvarig, och ett spår i historiken — kopplat till lagen i er egen laglista.'
 ---
 
-Lagbevakning har länge betytt ett nyhetsbrev eller ett ändringsflöde: en notis om att något hänt, följd av paragraftext som någon hos er förväntas läsa, tolka och agera på. Det är just där arbetet börjar — och där de flesta tjänster slutar.
+<Lead>
+  Lagbevakning har länge betytt ett nyhetsbrev eller ett ändringsflöde: en notis
+  om att något hänt, följd av paragraftext som någon hos er förväntas läsa,
+  tolka och agera på.
+</Lead>
+
+Det är just där arbetet börjar — och där de flesta tjänster slutar.
 
 Laglig bevakar lagändringar som en del av laglistan. När en lag ni följer ändras landar ändringen sammanfattad på klarspråk, med en AI-förberedd bedömning av vad den betyder för er verksamhet. Ni tar ställning, dokumenterar och går vidare — och historiken byggs medan ni arbetar.
 

--- a/content/marketing/funktioner/laglista.mdx
+++ b/content/marketing/funktioner/laglista.mdx
@@ -50,7 +50,12 @@ faq:
     answer: 'Vanligen KMA-, kvalitets- eller miljöansvarig som ägare av listan som helhet — men ledningen bär det yttersta ansvaret. I Laglig kan varje lag och kravpunkt dessutom ha en egen ansvarig, så att ansvaret blir synligt i stället för underförstått.'
 ---
 
-En laglista är en förteckning över de lagar, förordningar och föreskrifter som gäller just er verksamhet — med en bedömning av vad varje krav betyder för er. Den är grunden i miljöbalkens egenkontroll, ett uttryckligt krav i ISO 14001 och ISO 45001, och det första en revisor ber att få se. Ändå lever den hos många som ett Excel-ark från en konsultleverans: korrekt vid leveransen, inaktuellt en lagändring senare.
+<Lead>
+  En laglista är en förteckning över de lagar, förordningar och föreskrifter som
+  gäller just er verksamhet — med en bedömning av vad varje krav betyder för er.
+</Lead>
+
+Den är grunden i miljöbalkens egenkontroll, ett uttryckligt krav i ISO 14001 och ISO 45001, och det första en revisor ber att få se. Ändå lever den hos många som ett Excel-ark från en konsultleverans: korrekt vid leveransen, inaktuellt en lagändring senare.
 
 Laglig bygger laglistan som en levande arbetsyta i stället för ett dokument: lagarna hämtas ur en katalog med över 47 000 författningar, förklaras på vanlig svenska, bryts ned i kravpunkter och bevakas när de ändras.
 

--- a/content/marketing/funktioner/styrdokument.mdx
+++ b/content/marketing/funktioner/styrdokument.mdx
@@ -52,7 +52,13 @@ faq:
     answer: 'Från 50 anställda kräver visselblåsarlagen (2021:890) en intern rapporteringskanal med utsedda mottagare, dokumenterade rutiner och bestämda svarstider. Kravet gäller oavsett bransch — och rutinen är ett typexempel på ett styrdokument som hör ihop med ett lagkrav.'
 ---
 
-"Vilka policyer måste ett företag ha?" är en av de vanligaste frågorna en ny VD, HR-ansvarig eller kvalitetsansvarig ställer — och svaret är mer konkret än de flesta tror. Lagen pekar ut ett antal dokument som ska finnas, och tröskelvärden som avgör när formkraven skärps.
+<Lead>
+  "Vilka policyer måste ett företag ha?" är en av de vanligaste frågorna en ny
+  VD, HR-ansvarig eller kvalitetsansvarig ställer — och svaret är mer konkret än
+  de flesta tror.
+</Lead>
+
+Lagen pekar ut ett antal dokument som ska finnas, och tröskelvärden som avgör när formkraven skärps.
 
 ## Vilka policyer och rutiner måste ett företag ha enligt lag?
 

--- a/content/marketing/funktioner/uppgifter.mdx
+++ b/content/marketing/funktioner/uppgifter.mdx
@@ -50,7 +50,12 @@ faq:
     answer: 'Avvikelsen lever som uppgift med status, ansvarig och aktivitetshistorik. Vid revisionen visar ni kedjan fynd → åtgärd → klart, med datum och personer — i stället för att leta i mejlkorgar efter vad som bestämdes.'
 ---
 
-"Otydlig ansvarsfördelning" och "bristande uppföljning av åtgärder" är två av de vanligaste avvikelserna vid ISO-revisioner — och de hänger ihop. En lagefterlevnadskontroll som hittar brister är bara halva jobbet; den andra halvan är att någon med namn och datum faktiskt åtgärdar dem. Det är den halvan som uppgifterna i Laglig finns för.
+<Lead>
+  "Otydlig ansvarsfördelning" och "bristande uppföljning av åtgärder" är två av
+  de vanligaste avvikelserna vid ISO-revisioner — och de hänger ihop.
+</Lead>
+
+En lagefterlevnadskontroll som hittar brister är bara halva jobbet; den andra halvan är att någon med namn och datum faktiskt åtgärdar dem. Det är den halvan som uppgifterna i Laglig finns för.
 
 ## Vem ansvarar för lagefterlevnaden? Ledningen – men uppgifterna måste fördelas
 

--- a/docs/prd/epic-26-page-inventory.md
+++ b/docs/prd/epic-26-page-inventory.md
@@ -1,0 +1,250 @@
+# Epic 26 — Marketing Page Inventory & Content Expansion Plan
+
+**Status:** Draft / planning artifact (2026-06-25)
+**Parent:** [`epic-26-marketing-pages-seo-content-engine.md`](./epic-26-marketing-pages-seo-content-engine.md)
+**Purpose:** Enumerate the full set of marketing/content pages to build on the existing Epic 26 substrate — each one targeting a Swedish search cluster **and** tied to a concrete laglig.se product angle, so every page works as both an SEO surface and a paid-ad landing page that converts into trial signup.
+
+---
+
+## 1. Where we stand
+
+The Epic 26 **substrate is built and working**:
+
+- 3 layout templates (`FeaturePageTemplate`, `IndustryPageTemplate`, `TopicPageTemplate`) + `BasePageTemplate` + `MarketingShell`
+- 12 section components (`MarketingHero`, `FeatureGrid`, `SplitFeature`, `ProofBlock`, `CtaBlock`, `OrgCheckCta`, `HeroOrgCheck`, `CatalogLawList`, `FaqAccordion`, `RelatedPagesGrid`, `ChangeFeedEmbed`, `ScreenshotFrame`)
+- MDX content surface (`content/marketing/{kind}/[slug].mdx`) with Zod-validated frontmatter (`lib/marketing/frontmatter-schemas.ts`)
+- Live catalog-link resolution (`lib/marketing/catalog-link.ts`), auto OG images, sitemap auto-registration, UTM CTA tracking
+
+**Live today: 14 pages** — 7 `funktioner` + 7 `branscher`. `/omraden` is routed but empty (0/8). `jamfor`, `kundcase`, `ordbok`, `blogg` not built.
+
+This document is the content build-out plan on top of that substrate. **Adding a page is editorial work (MDX file + ~30-min review), not engineering** — except for the small additions in §4 and the one programmatic route in §8.
+
+---
+
+## 2. Strategic frame
+
+### Inspiration analysed
+- **Notisum kunskapsbank** (~25 evergreen concept/reference pages) — they own the *generic Swedish compliance vocabulary* (laglista, lagbevakning, lagefterlevnad, miljöbalken, ISO 14001, internrevision…). Four archetypes: concept/method, ISO standards, legislation explainers, management-system concepts.
+- **Fieldly funktioner** (~16 pages, one per capability, grouped megamenu under `/produkt/[feature]`) — the model for a complete, granular feature cluster.
+
+### The differentiator (why we outperform, not just match)
+Notisum's concept pages are **static prose that goes stale**. Our three structural advantages make every page *live*:
+1. **Live catalog** — 10k+ law pages (`/lagar/*`, `/foreskrifter/*`, `/eu/*`) linked via `<CatalogLawList>`, with current consolidated text + amendments.
+2. **Live change feed** — `<ChangeFeedEmbed>` shows recent changes per area (freshness signal Google + AI answer engines reward).
+3. **AI agent + org-number check** — interactive "testa med ditt organisationsnummer" conversion device on every page.
+
+A legislation explainer like `miljöbalken` is the sharpest example: notisum *describes* the law; we link the **actual live text + every amendment + the change feed** — something they cannot replicate without rebuilding our catalog.
+
+---
+
+## 3. The product-angle rule (applies to every page)
+
+Same conversion machine on all pages (org-check + UTM trial CTA), but the **hook** is tailored to intent. Native, concise Swedish — no fluff. Reference hooks:
+
+| Archetype | Hook (Swedish) |
+|---|---|
+| Lagförklaring | *"Miljöbalken ändras flera gånger om året. Laglig.se bevakar varje ändring åt dig — kopplad direkt till din laglista."* |
+| ISO-standard | *"ISO 14001 kräver en aktuell förteckning över bindande krav. Laglig.se bygger den åt dig och håller den uppdaterad."* |
+| Begrepp/metod | *"Internrevision utan kalkylblad — planera, genomför och dokumentera lagefterlevnadskontrollen."* |
+| Bransch | *"Vilka AFS-föreskrifter gäller för ditt byggföretag? Ange organisationsnummer, så visar vi din laglista."* |
+| Intersection | *"GDPR för IT-bolag — exakt vilka krav som gäller, samlade och bevakade i Laglig.se."* |
+
+**Copy must match the *current* product.** (Example caught this session: there is no SHA-256/cryptographic signing anymore — Story 21.26/21.27 removed it. The reports feature is a **Revisionsrapport**: a completed cycle is låst/avslutad with who+when, each bedömning signerad av ansvarig, exported as PDF. No integrity/hash claims.) Verify each page's feature description against live code before publishing.
+
+---
+
+## 3.1 Content quality & SEO standards (every page)
+
+**Grounded, not hallucinated.** All factual content — laws, paragraphs, requirements, dates, standard clauses — must be researched against **primary sources**: our own catalog/corpus (live `LegalDocument` text + amendments) and official sources (riksdagen.se / SFS, Arbetsmiljöverket / AFS, Boverket, MSB, Naturvårdsverket, IMY, EUR-Lex, SIS / ISO). No invented citations, section numbers, or "facts". When unsure, link to the catalog page rather than paraphrase. The catalog is the source of truth for anything legal; product claims are cross-checked against live code (§3).
+
+**Language.** Native, professional Swedish — correct grammar, natural phrasing, high readability (short sentences, clear structure, no machine-translation feel). A grammar/readability pass per page.
+
+**Per-page SEO (frontmatter + on-page):**
+
+- **Meta title** — unique, ≤ 60 chars, primary keyword front-loaded, brand suffix where it fits.
+- **Meta description** — unique, ~150–160 chars, primary + one long-tail, soft CTA.
+- **One H1** (keyword-bearing); H2/H3 structured around sub-intents and natural long-tail phrasings (real search questions).
+- **Long-tail coverage** — weave a fair set of variants ("vad kostar", "krav", "checklista", "för [bransch]", "mall", "exempel") into headings, body, and FAQ — without keyword stuffing.
+- **FAQ** (already required) — questions phrased as real search queries; powers FAQPage JSON-LD + AI-answer citability.
+- **Internal links** — `<CatalogLawList>` to the catalog + `relatedPages` to siblings; descriptive anchor text.
+- **Canonical + OG** — via `generateMarketingMetadata()`; ensure canonical is unique per page (esp. the lagguide-vs-catalog split, §6).
+- **Image SEO** — meaningful `alt` on every screenshot/photo.
+
+**Definition of done (per page):** sources verified · grammar pass · unique meta title + description · long-tail in headings/FAQ · ≥ 90 Lighthouse SEO.
+
+---
+
+## 4. Architecture decisions
+
+1. **Extend `omraden`, don't invent template kinds.** The `TopicPageTemplate` renders concept/ISO/legislation/regulatory pages. Avoids a new route/schema/nav column + a second validation gate.
+2. **Two new section components** (the ~10% the current 12 don't cover):
+   - `<DefinitionBox>` — featured-snippet "Vad är X?" answer box (notisum's strongest SEO device; feeds AI answer engines). Optional `definition` frontmatter field.
+   - `<ProcessSteps>` — numbered steps for "certifiering steg-för-steg" and the `Vad?/Hur?/Vem?/När?` framework.
+   - (`<ComparisonTable>` for `/jamfor` already scoped in Story 26.9.)
+3. **`/kunskapsbank` hub** — a discovery surface (we only have the megamenu today) aggregating `omraden` + concept pages + `ordbok`, grouped by the 4 archetypes. Strong internal-linking nexus. No new page *kind* — just an index.
+4. **Cannibalization guard** — do NOT build concept `laglista` / `lagefterlevnadskontroll` pages that compete with `/funktioner/laglista` and `/funktioner/kontroller`. Instead enrich those feature pages with a "Vad är …?" `<DefinitionBox>` so they own concept-intent too. One URL per keyword.
+5. **Funktioner megamenu → grouped** (Fieldly-style). At 15 pages the flat list in `nav-links.ts` becomes 5 category groups (see §5.1). Do this before adding the new feature pages.
+6. **Megamenu overflow → category/index pages + "Visa alla".** The megamenu can't surface 15 funktioner / 20 branscher / 49 områden without becoming a wall. So each column shows a curated top set, then a **"Visa alla →"** link to a category/index page (`/funktioner`, `/branscher`, `/omraden`) that showcases the full set as a card grid grouped by category (see §5.8). The footer mirrors the same "Visa alla" links. Design reference already exists: `_prototypes/marketing-site/branscher.html` (3-col industry card grid hub).
+
+---
+
+## 5. Page inventory
+
+### 5.1 Funktioner — 8 new → 15 total (Fieldly model)
+
+Live: laglista, lagbevakning(=lagandringar), kontroller, kravpunkter, styrdokument, uppgifter, ai-agent.
+
+| Page | Status | Group | Product angle / target |
+|---|---|---|---|
+| Laglista | live | Bevakning & laglista | bygg/importera laglista |
+| Lagbevakning *(rename target of `lagandringar`)* | live | Bevakning & laglista | own "lagbevakning" (higher volume than "lagändringar") |
+| **Lagkatalog & rättskällor** | 🆕 | Bevakning & laglista | the 10k+ live catalog — unique vs Notisum/Fieldly |
+| **AI-sammanfattningar** | 🆕 | Bevakning & laglista | "AI sammanfattning lag" |
+| Kontroller (lagefterlevnadskontroll) | live | Efterlevnad & kontroll | audit cycles |
+| Kravpunkter / kravhantering | live | Efterlevnad & kontroll | gap-analys |
+| **Revisionsrapport** | 🆕 | Efterlevnad & kontroll | completed-cycle PDF report (no integrity claims); auditor angle |
+| **Mallar** | 🆕 | Efterlevnad & kontroll | reusable audit/control templates |
+| Styrdokument | live | Styrning & dokumentation | policy library |
+| **Filer & dokumenthantering** | 🆕 | Styrning & dokumentation | evidence/docs tied to krav |
+| Uppgifter | live | Arbete & samarbete | kanban/list/calendar |
+| **Ansvar & samarbete** | 🆕 | Arbete & samarbete | distributed ownership |
+| **Aktivitetslogg & spårbarhet** | 🆕 | Arbete & samarbete | audit trail — auditor hook |
+| AI-agent | live | AI & automation | the differentiator |
+| **Importera laglista** | 🆕 | AI & automation | migration intent ("flytta laglista från Excel/Notisum"); bridges from `/jamfor` |
+
+Reserve (build only if search volume justifies): behörigheter & roller, integrationer/API, översikt/dashboard.
+
+### 5.2 Branscher — 13 new → 20 total
+
+Live: bygg, fastighet, hotell-restaurang, industri, it, transport, vård-omsorg.
+
+New: livsmedel/produktion · handel/detaljhandel · energi & el · kemi/kemikalieindustri · lantbruk · avfall & återvinning · offentlig sektor/kommun · skola & utbildning · BRF/bostadsrättsförening · åkeri & logistik · tandvård · verkstadsindustri · gruvor & täkter.
+
+Angle: *"färdig laglista för [bransch], anpassad efter ditt org.nr."*
+
+### 5.3 Områden — ~49 new
+
+**A. Kärnområden (8)** — already planned: GDPR · NIS2 · Arbetsmiljö · Brandskydd · Miljö · Visselblåsarlagen · Penningtvätt · ISO 14001
+
+**B. ISO-svit (5):** ISO 45001 · ISO 9001 · ISO 50001 · ISO 27001/27000 · ISO 9000
+
+**C. Begrepp & metod (6):** Lagrevision · Internrevision · Ledningssystem · Miljöledningssystem · Kvalitetsledningssystem · Lagefterlevnad
+
+**D. Lagförklaringar (15 curated → expands to the Lagguide-bibliotek, §6):** Miljöbalken · Arbetsmiljölagen · AFS · Plan- och bygglagen (PBL) · Lag om skydd mot olyckor (LSO) · Livsmedelslagen · Alkohollagen · LAS · Diskrimineringslagen · Elsäkerhetslagen · Arbetstidslagen · Avfallsförordningen · REACH · Boverkets byggregler (BBR) · Strålskyddslagen
+
+**E. Regulatoriska teman (15):** CSRD/hållbarhetsrapportering · EU-taxonomin · AI Act · DORA · Systematiskt arbetsmiljöarbete (SAM) · Systematiskt brandskyddsarbete (SBA) · OVK · Egenkontroll · CE-märkning · Maskindirektivet · Riskbedömning · Kemikalieförteckning · Energikartläggning (EKL) · ESG · Avfallstrappan
+
+### 5.4 Jämför — 6 new
+Notisum · Karnov · JP Infonet · Laglista i Excel · Manuell lagbevakning · Generiska ledningssystem-verktyg. (Uses `<ComparisonTable>`, Story 26.9. Each includes a fair "När [konkurrent] passar bättre" section.)
+
+### 5.5 Kundcase — 3–5 new
+Templated, customer-dependent. **Almåsa is excluded** (real demo workspace — never feature in marketing). Start with 2–3 confirmed customers, grow editorially.
+
+### 5.6 Ordbok — ~35 starter terms (→ 60)
+laglista · lagbevakning · lagefterlevnad · efterlevnadskontroll · kravpunkt · bindande krav · rättskälla · föreskrift · förordning · direktiv · författningssamling · internrevision · lagrevision · ledningssystem · styrdokument · revisionsrapport · avvikelse · riskbedömning · egenkontroll · AFS · miljöbalken · OVK · SBA · SAM · CE-märkning · REACH · GDPR · NIS2 · ISO 14001 · ISO 45001 · ISO 9001 · visselblåsarlagen · penningtvätt · CSRD · ESG
+
+### 5.7 Hub & conversion supports — 6 new
+`/kunskapsbank` (hub) · `/ordbok` (index) · `/jamfor` (index) · `/kom-igang` · `/demo` · `/blogg` (substrate + 2 launch posts)
+
+### 5.8 Category / index pages — 3 new
+
+The "Visa alla" destinations from the megamenu + footer (§4.6). Each showcases its full set as a card grid grouped by category, is a strong internal-linking nexus, and ranks for the head term:
+
+- `/funktioner` — all features, grouped by the 5 funktioner categories (§5.1)
+- `/branscher` — all industries, card grid (head term "laglista per bransch"; design ref `_prototypes/marketing-site/branscher.html`)
+- `/omraden` — all topics, grouped by the 4 archetypes; may serve as / merge with `/kunskapsbank` (decide at build to avoid duplication)
+
+---
+
+## 6. Lagguide-bibliotek — top 50–100 B2B laws (the biggest catalog lever)
+
+Expand §5.3-D from 15 hand-written explainers into a **50–100 page library** of the most B2B-relevant laws/föreskrifter.
+
+**Data-driven ranking (no guessing):**
+- Rank by frequency in `LawListTemplate` / `TemplateItem` (schema ~line 1817) — laws appearing across the most standard industry lists = the top B2B laws by definition.
+- Seed each page's "vad innebär den för ditt företag" from the existing **`business_context`** field on the law model (schema ~line 396: *"Why this law matters to the business"*). Half the content per page already exists in the DB.
+
+**Two tiers (avoid duplicating our own catalog pages):**
+- **Top ~20 = full hand-written explainers** (the §5.3-D set) — real depth, real search volume.
+- **Long tail to ~100 = programmatic `/lagguide/[slug]`** — catalog-backed: live summary + amendments + change feed + `business_context` + "så hjälper Laglig.se dig efterleva [lag]". Cross-linked to the catalog page; canonicals split by intent.
+
+| Surface | Intent | Owns keyword |
+|---|---|---|
+| Catalog `/lagar/[id]` (exists) | "läs lagtexten" — research | the law-text query |
+| Lagguide `/lagguide/[slug]` (new) | "vad innebär den + hur efterlever jag" — commercial | "[lag] krav / sammanfattning / checklista" |
+
+**TODO:** run the ranking query over `LawListTemplate`/`TemplateItem` joined to `business_context` to produce the concrete prioritized top-100 list.
+
+---
+
+## 7. Programmatic intersection pages (the ad-scaling reserve)
+
+Catalog-backed, ideal paid-ad landing pages, **not thin** because each ships a *different* real law list via `<CatalogLawList>`:
+
+- **Bransch × Område** — e.g. "GDPR för byggföretag", "SBA i hotell". 20 industries × ~15 topics = up to 300; launch high-intent ~60–100 first.
+- **Funktion × Bransch** — e.g. "Laglista för åkeri". Launch ~40.
+
+All three programmatic families (lagguide + the two intersections) ride **one new catalog-backed route** — the single highest-leverage build for the ads goal. Log any coverage caps; never silently truncate.
+
+---
+
+## 8. Totals
+
+| Cluster | New pages |
+|---|---|
+| Funktioner | 8 |
+| Branscher | 13 |
+| Områden | ~49 |
+| Jämför | 6 |
+| Kundcase | 3–5 |
+| Ordbok | ~35 (→60) |
+| Hub & supports | 6 |
+| Category / index pages | 3 |
+| **Curated subtotal** | **~124** |
+| Lagguide-bibliotek (programmatic-curated) | +50–100 |
+| Bransch×Område + Funktion×Bransch (programmatic) | +100–300 |
+
+From 14 live → **~138 curated**, comfortably past Notisum's ~25, with the programmatic layer as the ad-scaling reserve.
+
+---
+
+## 9. Imagery / hero mockups (open)
+
+Hero shots use real in-app screenshots (committed under `public/images/marketing/`). Direction for premium device mockups is **still being decided** (this session):
+- Rejected: home-rolled CSS laptop; procedural Three.js 3D render (not photoreal enough).
+- Current lead: **LS Graphics "MacBook Neo" (6K, isolated/transparent, photoreal)** — either (1) hand-made via their "Edit Online" editor for the ~15–20 hero pages (max quality, no pipeline), or (2) automated via the Neo PSD + Dynamic Mockups API for all pages.
+- People photography (industry pages) via Nano Banana 2 — offline editorial, committed as WebP. AI image gen is NOT used for screenshots (distorts UI).
+
+A `mockup` heroMedia type (renders the transparent image bare, no frame) will be added once the route is chosen.
+
+---
+
+## 10. Sequencing into Epic 26 stories
+
+- **26.5 / 26.6** — remaining Tier-1 branscher + funktioner (existing scope; §5.1–5.2 new funktioner fold in here).
+- **26.7 / 26.8** — `omraden` kärnområden (§5.3-A), as planned.
+- **New 26.7b** — ISO-svit (§5.3-B) + `<DefinitionBox>`/`<ProcessSteps>` components (validated against real content, like the 26.4 gate).
+- **New 26.8b** — begrepp/metod (§5.3-C) + lagförklaringar top 20 (§5.3-D).
+- **New 26.x (route)** — programmatic catalog-backed route → Lagguide-bibliotek (§6) + intersections (§7).
+- **26.9 / 26.10 / 26.11 / 26.12** — jämför / conversion supports / ordbok / blogg, as in parent PRD.
+- **New** — `/kunskapsbank` hub (small).
+
+**Recommended first content batch:** Tier-C lagförklaringar (miljöbalken, arbetsmiljölagen, AFS) — proves the live-catalog differentiator before scaling.
+
+---
+
+## 11. Open items
+
+- [ ] Run the `LawListTemplate`/`business_context` ranking query → concrete top-100 B2B law list (§6).
+- [ ] Decide hero-mockup route (§9).
+- [ ] Confirm in-product naming ("revisionsrapport"?) before publishing feature copy.
+- [ ] Additional competitor/inspiration URLs (only the Notisum kunskapsbank link was provided this session).
+
+---
+
+## Change log
+
+| Date | Version | Description | Author |
+|------|---------|-------------|--------|
+| 2026-06-25 | 0.1 | Initial page-inventory plan: full new-page enumeration (~121 curated + 50–100 lagguide + 100–300 programmatic), notisum/Fieldly analysis, extend-`omraden` decision, cannibalization guard, Lagguide-bibliotek data-driven method, programmatic route, mockup direction status. Captured from planning session with Alexander. | Claude + Alexander |
+| 2026-06-25 | 0.2 | Added §3.1 content-quality & SEO standards (grounded/non-hallucinated content from corpus + official sources, Swedish grammar/readability, per-page meta title/description + long-tail + per-page Definition of Done); added megamenu-overflow decision (§4.6) + §5.8 category/index pages (`/funktioner`, `/branscher`, `/omraden` "Visa alla" hubs). Curated total ~121 → ~124. | Claude + Alexander |

--- a/docs/prd/epic-26-page-inventory.md
+++ b/docs/prd/epic-26-page-inventory.md
@@ -66,7 +66,7 @@ Same conversion machine on all pages (org-check + UTM trial CTA), but the **hook
 - **One H1** (keyword-bearing); H2/H3 structured around sub-intents and natural long-tail phrasings (real search questions).
 - **Long-tail coverage** — weave a fair set of variants ("vad kostar", "krav", "checklista", "för [bransch]", "mall", "exempel") into headings, body, and FAQ — without keyword stuffing.
 - **FAQ** (already required) — questions phrased as real search queries; powers FAQPage JSON-LD + AI-answer citability.
-- **Internal links** — `<CatalogLawList>` to the catalog + `relatedPages` to siblings; descriptive anchor text.
+- **Internal links** — cross-link across the whole set **where it genuinely helps the reader**: bransch ↔ område ↔ funktion ↔ lagguide ↔ ordbok ↔ catalog (`<CatalogLawList>` to laws, `relatedPages` for the sibling-grid, a few natural in-body links). A handful of contextual, relevant links per page — **don't overdo it / no link farms**. Descriptive anchor text, never "läs mer".
 - **Canonical + OG** — via `generateMarketingMetadata()`; ensure canonical is unique per page (esp. the lagguide-vs-catalog split, §6).
 - **Image SEO** — meaningful `alt` on every screenshot/photo.
 
@@ -158,7 +158,7 @@ The "Visa alla" destinations from the megamenu + footer (§4.6). Each showcases 
 
 ## 6. Lagguide-bibliotek — top 50–100 B2B laws (the biggest catalog lever)
 
-Expand §5.3-D from 15 hand-written explainers into a **50–100 page library** of the most B2B-relevant laws/föreskrifter.
+Build content pages for the **top 50–100 laws/föreskrifter that apply to companies** — expand §5.3-D from 15 hand-written explainers into a full **50–100 page library** of the most B2B-relevant legislation. This is the single biggest SEO opportunity in the epic: high-intent legal terms that competitors cover only with thin, static prose, while ours are backed by live catalog data + structured markup. Real chance to outrank them at scale.
 
 **Data-driven ranking (no guessing):**
 - Rank by frequency in `LawListTemplate` / `TemplateItem` (schema ~line 1817) — laws appearing across the most standard industry lists = the top B2B laws by definition.
@@ -172,6 +172,8 @@ Expand §5.3-D from 15 hand-written explainers into a **50–100 page library** 
 |---|---|---|
 | Catalog `/lagar/[id]` (exists) | "läs lagtexten" — research | the law-text query |
 | Lagguide `/lagguide/[slug]` (new) | "vad innebär den + hur efterlever jag" — commercial | "[lag] krav / sammanfattning / checklista" |
+
+**Structured data (featured-snippet + AI-answer capture).** Every lagguide page emits JSON-LD — `BreadcrumbList` + `Article` + `FAQPage` (from the visible `<FaqAccordion>`) — and leads with a `<DefinitionBox>` ("Vad är [lag]?") + `<ProcessSteps>` where relevant, all structured for featured-snippet and AI-answer-engine capture. Markup/visible-content parity is required (Google rule). This is where the SEO gain compounds: ~50–100 pages × structured Q&A + definition boxes on terms the competition leaves as plain text.
 
 **TODO:** run the ranking query over `LawListTemplate`/`TemplateItem` joined to `business_context` to produce the concrete prioritized top-100 list.
 
@@ -248,3 +250,4 @@ A `mockup` heroMedia type (renders the transparent image bare, no frame) will be
 |------|---------|-------------|--------|
 | 2026-06-25 | 0.1 | Initial page-inventory plan: full new-page enumeration (~121 curated + 50–100 lagguide + 100–300 programmatic), notisum/Fieldly analysis, extend-`omraden` decision, cannibalization guard, Lagguide-bibliotek data-driven method, programmatic route, mockup direction status. Captured from planning session with Alexander. | Claude + Alexander |
 | 2026-06-25 | 0.2 | Added §3.1 content-quality & SEO standards (grounded/non-hallucinated content from corpus + official sources, Swedish grammar/readability, per-page meta title/description + long-tail + per-page Definition of Done); added megamenu-overflow decision (§4.6) + §5.8 category/index pages (`/funktioner`, `/branscher`, `/omraden` "Visa alla" hubs). Curated total ~121 → ~124. | Claude + Alexander |
+| 2026-06-25 | 0.3 | §6: framed the top 50–100 B2B laws/föreskrifter as the biggest SEO lever and added the structured-data spec (BreadcrumbList + Article + FAQPage + DefinitionBox/ProcessSteps for featured-snippet & AI-answer capture). §3.1: expanded internal-linking rule (cross-link bransch↔område↔funktion↔lagguide↔ordbok↔catalog where relevant; don't overdo it). | Claude + Alexander |

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -4,6 +4,7 @@ import { SplitFeature } from '@/components/marketing/sections/split-feature'
 import { ScreenshotFrame } from '@/components/marketing/media/screenshot-frame'
 import { FeatureGrid } from '@/components/marketing/sections/feature-grid'
 import { ProofBlock } from '@/components/marketing/sections/proof-block'
+import { Lead } from '@/components/marketing/mdx/lead'
 
 /**
  * Global MDX component map — required by @next/mdx with the App Router.
@@ -128,6 +129,8 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
         {children}
       </code>
     ),
+    // Standfirst/deck for the article lede (see components/marketing/mdx/lead).
+    Lead,
     // Marketing section components usable inline in any MDX body (Story 26.4
     // bridge rows). These render full-width — they are not PROSE-wrapped.
     SplitFeature,


### PR DESCRIPTION
## Summary

Two distinct bodies of work on this branch:

### Marketing UI (code)
- **New `<Lead>` deck component** (`components/marketing/mdx/lead.tsx`) for the article standfirst, registered in the global MDX component map.
- **Removed the breadcrumb row** from `MarketingShell` (dropped the `breadcrumbs` prop) — the hero eyebrow + megamenu navbar already handle orientation/up-nav, so the "Hem › … " trail was redundant and heavier-looking. Updated `base-page-template`, `hero-org-check`, `(marketing)/layout`, and all funktioner/branscher MDX to match.
- (Also carries an earlier `copy(hero)` commit: plainer, path-neutral hero subtitle.)

### Epic 26 planning (docs)
- **`docs/prd/epic-26-page-inventory.md`** — full marketing page-inventory expansion plan: ~124 curated new pages + 50–100 lagguide + 100–300 programmatic.
  - Notisum/Fieldly analysis + the live-catalog differentiator
  - Extend-`omraden` decision, cannibalization guard, two new section components, grouped funktioner megamenu
  - **Megamenu-overflow → `/funktioner` `/branscher` `/omraden` category "Visa alla" pages**
  - **Lagguide-bibliotek** (top 50–100 B2B laws), data-driven ranking via `LawListTemplate` + `business_context`, with **structured data** for featured-snippet/AI-answer capture
  - **Content-quality & SEO standards** (grounded/non-hallucinated from corpus + official sources, Swedish grammar, per-page meta + long-tail + internal-linking rule)

## Notes
- ⚠️ **Branch name is a leftover** (`feat/marketing-hero-mockups`) — the hero-mockup experiment it was created for was abandoned/reverted; the branch now holds the MDX work + planning doc. Rename or merge as-is, your call.
- Typecheck passes (`pnpm typecheck`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)