### PR TITLE
fix(marketing): render MDX tables + align inline <Lead> deck to prose column

### DIFF
--- a/components/marketing/mdx/lead.tsx
+++ b/components/marketing/mdx/lead.tsx
@@ -2,12 +2,18 @@ import type { ReactNode } from 'react'
 
 /**
  * Standfirst/deck for a marketing article's lede. Authors wrap the opening
- * sentence in `<Lead>…</Lead>` in MDX; Prettier reflows that to block form, so
- * the child is a real `<p>` (which keeps the centered PROSE width from the
- * global `p` mapping in mdx-components.tsx). We restyle that child here — bigger
- * and in the ink color — via `[&>p]`, so the lede reads as an intentional intro
- * rather than orphaned body text under the hero, with no heading competing with
- * the H1.
+ * sentence in `<Lead>…</Lead>` in MDX. We restyle it — bigger and in the ink
+ * color — so the lede reads as an intentional intro rather than orphaned body
+ * text under the hero, with no heading competing with the H1.
+ *
+ * This wrapper owns the centered PROSE width itself (`mx-auto max-w-3xl px-4`),
+ * so the lede aligns with the body column regardless of how MDX renders the
+ * child: block form (`<Lead>` with the sentence on its own line) wraps it in a
+ * real `<p>`, while inline form (`<Lead>…</Lead>` on one line) leaves bare text
+ * with no `<p>`. The `[&>p]` rules restyle that inner `<p>` when present and
+ * strip its own PROSE width/margins so it doesn't double up on this wrapper.
+ * (Previously the width lived only on the inner `<p>`, so the inline form had no
+ * `<p>` and the text bled flush-left to the viewport edge.)
  *
  * Lives under components/ (not inline in mdx-components.tsx) so Tailwind's
  * content scan actually generates these `[&>p]:` arbitrary-variant utilities —
@@ -15,7 +21,7 @@ import type { ReactNode } from 'react'
  */
 export function Lead({ children }: { children: ReactNode }) {
   return (
-    <div className="[&>p]:mb-2 [&>p]:mt-1 [&>p]:text-lg [&>p]:leading-relaxed [&>p]:text-foreground/90 sm:[&>p]:text-xl">
+    <div className="mx-auto mb-2 mt-1 w-full max-w-3xl px-4 text-lg leading-relaxed text-foreground/90 sm:text-xl [&>p]:m-0 [&>p]:max-w-none [&>p]:px-0 [&>p]:text-lg [&>p]:leading-relaxed [&>p]:text-foreground/90 sm:[&>p]:text-xl">
       {children}
     </div>
   )

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -26,9 +26,11 @@ const outputFileTracingRoot = process.env.VERCEL ? undefined : projectRoot
 // Plugins are passed as strings (Turbopack requirement: no JS functions
 // cross the Rust boundary). remark-frontmatter keeps the YAML block out of
 // the rendered output; parsing/validation happens in lib/marketing/content.ts.
+// remark-gfm enables GitHub-flavored markdown (tables, strikethrough, task
+// lists, autolinks) — without it, table syntax renders as raw pipe text.
 const withMDX = createMDX({
   options: {
-    remarkPlugins: ['remark-frontmatter'],
+    remarkPlugins: ['remark-frontmatter', 'remark-gfm'],
   },
 })
 


### PR DESCRIPTION
## Summary

Fixes two rendering bugs spotted on the preview deploy of the **funktioner** marketing pages.

### 1. Tables rendered as raw pipe text (kravpunkter)
The marketing MDX pipeline in `next.config.mjs` only loaded `remark-frontmatter`, so GitHub-flavored-markdown tables were never parsed — the kravpunkter checklist table rendered as a run-on `| Kravpunkt | Ansvarig | … |` paragraph.

**Fix:** enable `remark-gfm` (already a dependency, `^4.0.1`) in the MDX `remarkPlugins`. `mdx-components.tsx` already styles `table`/`th`/`td`, so the table now renders styled. This also enables strikethrough, task lists and autolinks across all marketing MDX.

### 2. Inline `<Lead>` bled flush-left to the viewport edge (kravpunkter + kontroller)
MDX only wraps a JSX component's child in a `<p>` when it's **block form** (sentence on its own line). The two affected pages authored the lede **inline** — `<Lead>En laglista säger…</Lead>` on one line — so there was no inner `<p>` to carry the centered `PROSE` width, and the bare text rendered full-width starting at the left viewport edge.

**Fix:** the `Lead` wrapper now owns the prose width itself (`mx-auto max-w-3xl px-4`) and resets the inner `<p>` so it doesn't double up. The lede now aligns with the body column whether authored inline or block — robust against either form (13 existing block-form pages unaffected; verified no regression).

## Test plan
- `/funktioner/kravpunkter` — checklist renders as a real styled table; lede aligns with the body column.
- `/funktioner/kontroller` — lede aligns with the body column.
- `/funktioner/laglista` (block-form `<Lead>`) — unchanged; lede + body text both start at the same x (verified 272px).
- `pnpm typecheck` ✓ · `prettier --check` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
