### PR TITLE
fix(landing): hero H1 'lagarna' → 'reglerna'

### DIFF
--- a/components/features/landing-v3/hero-v3.tsx
+++ b/components/features/landing-v3/hero-v3.tsx
@@ -29,7 +29,7 @@ export function HeroV3() {
             className="mb-5 max-w-5xl text-[2.5rem] font-medium leading-[1.05] tracking-tight sm:text-5xl md:text-6xl lg:text-[4.75rem]"
             style={{ fontFamily: "'Safiro', system-ui, sans-serif" }}
           >
-            <span className="block animate-fade-up">Håll koll på lagarna.</span>
+            <span className="block animate-fade-up">Håll koll på reglerna.</span>
             <span className="block animate-fade-up-delay-1 text-foreground/45">
               Automatiskt.
             </span>

--- a/components/features/landing-v3/hero-v3.tsx
+++ b/components/features/landing-v3/hero-v3.tsx
@@ -29,7 +29,9 @@ export function HeroV3() {
             className="mb-5 max-w-5xl text-[2.5rem] font-medium leading-[1.05] tracking-tight sm:text-5xl md:text-6xl lg:text-[4.75rem]"
             style={{ fontFamily: "'Safiro', system-ui, sans-serif" }}
           >
-            <span className="block animate-fade-up">Håll koll på reglerna.</span>
+            <span className="block animate-fade-up">
+              Håll koll på reglerna.
+            </span>
             <span className="block animate-fade-up-delay-1 text-foreground/45">
               Automatiskt.
             </span>


### PR DESCRIPTION
Changes the landing page hero H1 from "Håll koll på lagarna." to "Håll koll på reglerna."

Single-line copy change in the active landing hero (`HeroV3`, used by `app/page.tsx`). Branched off `main`, isolated from in-progress work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)